### PR TITLE
Add Claude GitHub Actions integration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,39 +20,23 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
-        )
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       ) || (
         github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
-        )
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       ) || (
         github.event_name == 'pull_request_review' &&
         github.event.review.body != null &&
         contains(github.event.review.body, '@claude') &&
-        (
-          github.event.review.author_association == 'OWNER' ||
-          github.event.review.author_association == 'MEMBER' ||
-          github.event.review.author_association == 'COLLABORATOR'
-        )
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
       ) || (
         github.event_name == 'issues' &&
         (
           (github.event.issue.body != null && contains(github.event.issue.body, '@claude')) ||
           contains(github.event.issue.title, '@claude')
         ) &&
-        (
-          github.event.issue.author_association == 'OWNER' ||
-          github.event.issue.author_association == 'MEMBER' ||
-          github.event.issue.author_association == 'COLLABORATOR'
-        )
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why?

The repository needs a way for team members to get on-demand assistance from Claude Code in issues and pull requests. The `/install-github-app` command initially added both an automatic PR review workflow and an @claude mention workflow. However, the repository already has a PR reviewer in place, making automatic reviews redundant and potentially intrusive.

## What Changed?

### Added @claude Mention Workflow (`claude.yml`)
- Triggers on `@claude` mentions in:
  - Issue comments
  - PR review comments
  - PR reviews
  - Issues (body or title)
- Security hardening:
  - Restricted to OWNER, MEMBER, and COLLABORATOR roles only
  - Pinned action to commit SHA `e8bad572273ce919ba15fec95aef0ce974464753` (v1)
  - Added 10-minute timeout to prevent runaway jobs
  - Configured concurrency groups to prevent duplicate runs
  - Added null checks for review and issue bodies
- Provides read permissions for contents, pull-requests, issues, and actions

### Removed Automatic PR Review Workflow
- Deleted `claude-code-review.yml` which automatically reviewed all new PRs
- Reason: Repository already has PR reviewer; automatic reviews not needed

### Security & Performance Controls
- Author association validation prevents unauthorized workflow triggers
- Concurrency control cancels duplicate runs for same issue/PR
- Timeout prevents jobs from running indefinitely
- Commit SHA pinning prevents supply chain attacks

## Testing

### Manual Test Plan
- [x] Trigger on issue creation with @claude in title
- [x] Trigger on issue edit with @claude in body
- [x] Trigger on issue comment with @claude mention
- [x] Trigger on PR review comment with @claude mention
- [x] Verify no automatic reviews on new PRs
- [x] Verify unauthorized users cannot trigger workflow

### CI Checks
All automated checks passing.

## Additional Notes

- [ ] Closes N/A (new feature, no associated issue)
- [ ] Spec ID(s): N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)