### PR TITLE
Add CLI entry point and package prompts for PyPI publishing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project.scripts]
-spec-driven-development-mcp = "server:mcp"
+spec-driven-development-mcp = "server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server", "prompts"]

--- a/server.py
+++ b/server.py
@@ -9,3 +9,14 @@ from mcp_server import create_app
 # Create the MCP server instance
 # The CLI looks for 'mcp', 'server', or 'app' at module level
 mcp = create_app()
+
+
+def main() -> None:
+    """Entry point for console script.
+
+    This function is called when the package is installed and run via:
+        uvx spec-driven-development-mcp
+
+    It runs the MCP server using stdio transport.
+    """
+    mcp.run()


### PR DESCRIPTION
## Why?

Issue #8 identified that the package structure was incomplete for PyPI publishing. The package was missing:
- A callable entry point for console script installation via uvx
- Prompt markdown files in the distribution
- The server.py module in the package

Without these fixes, users would not be able to install and run the package via `uvx spec-driven-development-mcp`.

## What Changed?

### Added CLI Entry Point
- Created `main()` function in `server.py` that calls `mcp.run()`
- Added `[project.scripts]` section to `pyproject.toml` pointing to `server:main`
- Enables installation and execution via `uvx spec-driven-development-mcp`

### Included Prompts Directory
- Updated `[tool.hatch.build.targets.wheel]` to include `prompts` package
- All 3 markdown prompt files now bundled in wheel:
  - `generate-spec.md`
  - `generate-task-list-from-spec.md`
  - `manage-tasks.md`

### Force-Included server.py
- Added `[tool.hatch.build.targets.wheel.force-include]` section
- Ensures `server.py` is included in distribution

### Fixed Entry Point Callability (CodeRabbit feedback)
- Changed entry point from non-callable `server:mcp` to callable `server:main`
- Prevents `TypeError: 'FastMCP' object is not callable` when running installed command

## Testing

Package builds successfully and contains all required files:
```bash
uv build
unzip -l dist/spec_driven_development_mcp-1.1.0-py3-none-any.whl
```

Verified contents:
- ✅ mcp_server/*.py (4 files)
- ✅ prompts/*.md (3 files)
- ✅ server.py
- ✅ Entry point: `spec-driven-development-mcp = server:main`

Entry point validation:
```bash
uv run python -c "from server import main; import inspect; print(f'main is callable: {callable(main)}'); print(f'main signature: {inspect.signature(main)}')"
# Output: main is callable: True
# Output: main signature: () -> None
```

## Additional Notes

- [x] Closes #8
- [ ] Spec ID(s): N/A (fixing existing implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a console script entry point for launching the MCP server directly from the command line.

* **Chores**
  * Updated wheel packaging configuration to include additional components and ensure proper file distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->