### PR TITLE
fix: update repo name in chainguard config

### DIFF
--- a/.github/chainguard/main-semantic-release.sts.yaml
+++ b/.github/chainguard/main-semantic-release.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://token.actions.githubusercontent.com
 # subject pattern is defining what repo and branch is allowed to generate a token at the permission level set below
-subject_pattern: "repo:liatrio-labs/spec-driven-workflow-mcp:ref:refs/heads/main"
+subject_pattern: "repo:liatrio-labs/spec-driven-workflow:ref:refs/heads/main"
 
 permissions:
   contents: write


### PR DESCRIPTION
Updated subject_pattern in `.github/chainguard/main-semantic-release.sts.yaml` to use current repo name 'spec-driven-workflow' instead of old name 'spec-driven-workflow-mcp'.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository reference in semantic release configuration to point to the primary project repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->