### PR TITLE
fix: update task name references to be consistent with new SDD- prefixes

### DIFF
--- a/prompts/SDD-1-generate-spec.md
+++ b/prompts/SDD-1-generate-spec.md
@@ -362,4 +362,4 @@ Iterate based on feedback until the user is satisfied.
 
 ## What Comes Next
 
-Once this spec is complete and approved, instruct the user to run `/generate-task-list-from-spec`. This will start the next step in the workflow, which is to break down the specification into actionable tasks.
+Once this spec is complete and approved, instruct the user to run `/SDD-2-generate-task-list-from-spec`. This will start the next step in the workflow, which is to break down the specification into actionable tasks.

--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -36,8 +36,8 @@ This task list serves as the **execution blueprint** for the entire SDD workflow
 
 **Critical Dependencies:**
 
-- **Parent tasks** become implementation checkpoints in `/manage-tasks`
-- **Proof Artifacts** guide implementation verification and become the evidence source for `/validate-spec-implementation`
+- **Parent tasks** become implementation checkpoints in `/SDD-3-manage-tasks`
+- **Proof Artifacts** guide implementation verification and become the evidence source for `/SDD-4-validate-spec-implementation`
 - **Task boundaries** determine git commit points and progress markers
 
 **What Breaks the Chain:**
@@ -87,7 +87,7 @@ Proof artifacts provide evidence of task completion and are essential for the up
 
 - **Demonstrate functionality** (screenshots, URLs, CLI output)
 - **Verify quality** (test results, lint output, performance metrics)
-- **Enable validation** (provide evidence for `/validate-spec-implementation`)
+- **Enable validation** (provide evidence for `/SDD-4-validate-spec-implementation`)
 - **Support troubleshooting** (logs, error messages, configuration states)
 
 **Security Note**: When planning proof artifacts, remember that they will be committed to the repository. Artifacts should use placeholder values for API keys, tokens, and other sensitive data rather than real credentials.
@@ -289,7 +289,7 @@ Before finalizing your task list, verify:
 
 ## What Comes Next
 
-Once this task list is complete and approved, instruct the user to run `/manage-tasks` to begin implementation. This maintains the workflow's progression from idea → spec → tasks → implementation → validation.
+Once this task list is complete and approved, instruct the user to run `/SDD-3-manage-tasks` to begin implementation. This maintains the workflow's progression from idea → spec → tasks → implementation → validation.
 
 ## Final Instructions
 
@@ -300,5 +300,5 @@ Once this task list is complete and approved, instruct the user to run `/manage-
 5. Ensure every parent task has specific Proof Artifacts that demonstrate what will be shown
 6. Identify all relevant files for creation/modification
 7. Review with user and refine until satisfied
-8. Guide user to the next workflow step (`/manage-tasks`)
+8. Guide user to the next workflow step (`/SDD-3-manage-tasks`)
 9. Stop working once user confirms task list is complete

--- a/prompts/SDD-3-manage-tasks.md
+++ b/prompts/SDD-3-manage-tasks.md
@@ -37,7 +37,7 @@ This implementation phase serves as the **execution engine** for the entire SDD 
 **Critical Dependencies:**
 
 - **Parent tasks** become implementation checkpoints and commit boundaries
-- **Proof artifacts** guide implementation verification and become the evidence source for `/validate-spec-implementation`
+- **Proof artifacts** guide implementation verification and become the evidence source for `/SDD-4-validate-spec-implementation`
 - **Task boundaries** determine git commit points and progress markers
 
 **What Breaks the Chain:**
@@ -203,7 +203,7 @@ Each parent task must include artifacts that:
 
 - **Demonstrate functionality** (screenshots, URLs, CLI output)
 - **Verify quality** (test results, lint output, performance metrics)
-- **Enable validation** (provide evidence for `/validate-spec-implementation`)
+- **Enable validation** (provide evidence for `/SDD-4-validate-spec-implementation`)
 - **Support troubleshooting** (logs, error messages, configuration states)
 
 ### Security Warning
@@ -291,7 +291,7 @@ After completing all tasks in the task list:
 2. **Proof Artifact Validation**: Verify all proof artifacts demonstrate functionality from original spec
 3. **Test Suite**: Run final comprehensive test suite
 4. **Documentation**: Update any relevant documentation
-5. **Handoff**: Instruct user to proceed to `/validate-spec-implementation`
+5. **Handoff**: Instruct user to proceed to `/SDD-4-validate-spec-implementation`
 
 The validation phase will use your proof artifacts as evidence to verify that the spec has been fully and correctly implemented.
 
@@ -344,4 +344,4 @@ Implementation is successful when:
 
 ## What Comes Next
 
-Once this task implementation is complete and all proof artifacts are created, instruct the user to run `/validate-spec-implementation` to verify the implementation meets all spec requirements. This maintains the workflow's progression from idea → spec → tasks → implementation → validation.
+Once this task implementation is complete and all proof artifacts are created, instruct the user to run `/SDD-4-validate-spec-implementation` to verify the implementation meets all spec requirements. This maintains the workflow's progression from idea → spec → tasks → implementation → validation.


### PR DESCRIPTION

## Why?
Some references to the slash command task names still used the old version without the SDD prefix, which could cause some confusion for the agents or users.

## What Changed?

Updated all names to references the new slash command names with `SDD-` prefixes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated workflow navigation and command triggers across specification documents to align with new step naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->