### PR TITLE
ci: add cspell spell-check for public documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,14 @@ repos:
       - id: markdownlint-fix
         exclude: "CHANGELOG.md|LICENSE"
 
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v9.7.0
+    hooks:
+      - id: cspell
+        name: spell check docs and prompts with cspell
+        files: ^(README\.md|CONTRIBUTING\.md|CODE_OF_CONDUCT\.md|\.github/pull_request_template\.md|prompts/.*\.md|docs/.*\.(md|html))$
+        exclude: ^docs/(references|assets)/
+
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.23.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,16 +77,23 @@ See the [pre-commit hooks documentation](https://pre-commit.com/hooks.html) for 
 ### Common Commands
 
 ```bash
+# Preview the docs site locally with hot reload
+uvx livereload --port 8012 docs/
+
 # Run full pre-commit checks across the repo
 pre-commit run --all-files
 
 # Run markdown linting only
 pre-commit run markdownlint-fix --all-files
+
+# Run docs and prompt spell checking only
+pre-commit run cspell --all-files
 ```
 
 ## Style and Quality
 
 - Markdown is linted using markdownlint (via pre-commit). Keep lines reasonably short and headings well structured.
+- Public-facing docs and workflow prompts are spell-checked with cspell. Add broadly reusable project terms to `cspell.config.yaml` and prefer file-specific config for one-off names.
 - YAML files are validated for syntax errors.
 - Commit messages must follow Conventional Commits specification (enforced via commitlint).
 - Keep documentation consistent with `README.md`.
@@ -104,6 +111,7 @@ This will:
 
 - Check YAML syntax
 - Fix Markdown formatting issues
+- Spell-check public-facing documentation and workflow prompts
 - Validate commit message format (on commit)
 
 ## Branching and Commit Conventions

--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ For comprehensive documentation, examples, and detailed guides, visit the **SDD 
 - **[Video Overview](https://liatrio-labs.github.io/spec-driven-workflow/video-overview.html)** — Visual walkthrough of the workflow
 - **[Reference Materials](https://liatrio-labs.github.io/spec-driven-workflow/reference-materials.html)** — Additional resources and examples
 
+To preview the playbook locally with hot reload, run:
+
+```bash
+uvx livereload --port 8012 docs/
+```
+
+Then open `http://localhost:8012`.
+
 ### Getting help
 
 - **Start here**: [Common Questions](https://liatrio-labs.github.io/spec-driven-workflow/common-questions.html)

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -33,6 +33,8 @@ overrides:
       - Kiro
       - SpecKit
       - speckit
+      - Tessl
+      - BMAD
 
   - filename: docs/index.html
     words:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,73 @@
+version: "0.2"
+language: en
+
+words:
+  - Liatrio
+  - SDD
+  - demoable
+  - pyproject
+
+ignorePaths:
+  - .git/**
+  - .venv/**
+  - docs/assets/**
+  - docs/references/**
+  - site/**
+  - temp/**
+
+ignoreRegExpList:
+  - /```[\s\S]*?```/g
+  - /<pre><code>[\s\S]*?<\/code><\/pre>/g
+
+overrides:
+  - filename: README.md
+    words:
+      - uvx
+      - Windsurf
+      - winget
+      - snarktank
+      - modelcontextprotocol
+
+  - filename: docs/comparison.html
+    words:
+      - Kiro
+      - SpecKit
+      - speckit
+
+  - filename: docs/index.html
+    words:
+      - Kiro
+      - SpecKit
+
+  - filename: docs/common-questions.html
+    words:
+      - Lada
+      - Kesseler
+
+  - filename: docs/emoji-context-verification-research.md
+    words:
+      - Lada
+      - Kesseler
+      - Philipp
+      - Schmid
+      - Automators
+
+  - filename: docs/developer-experience.html
+    words:
+      - pytest
+      - typer
+      - fastmcp
+      - reimagines
+
+  - filename: prompts/SDD-3-manage-tasks.md
+    words:
+      - oneline
+      - pytest
+
+  - filename: prompts/SDD-2-generate-task-list-from-spec.md
+    words:
+      - pytest
+
+  - filename: .github/pull_request_template.md
+    words:
+      - pytest


### PR DESCRIPTION
## Why?

Adds automated spell-checking to the pre-commit pipeline so documentation typos are caught before merge.

## What Changed?

- Added cspell pre-commit hook in `.pre-commit-config.yaml`
- Added `cspell.config.yaml` with project dictionary and file patterns
- Updated `CONTRIBUTING.md` with cspell setup instructions
- Updated `README.md` with local docs preview command

## Notes

- Ordering: Independent, no merge dependency on other split PRs
- Process: Split from `feat/add-pre-commit-for-cspell` using two-phase branch surgery
- Companion PR: #49 (site content updates)