### PR TITLE
docs(site): refine SDD messaging and overhaul comparison page

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -68,6 +68,11 @@ body {
     min-height: 100vh;
 }
 
+a {
+    color: var(--accent-green);
+    text-decoration: none;
+}
+
 /* Code styling - applies to all code elements, but not pre elements */
 code:not(pre code) {
     background-color: rgba(137, 223, 0, 0.15);
@@ -476,6 +481,47 @@ nav {
     font-weight: 600;
 }
 
+.before-scenario .phase-detail {
+    margin-bottom: 1.5rem;
+    padding: 2rem;
+    background-color: var(--box-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.before-scenario .phase-detail:nth-of-type(even) {
+    background-color: rgba(137, 223, 0, 0.06);
+    border-color: rgba(137, 223, 0, 0.18);
+}
+
+.before-scenario .phase-detail:hover {
+    transform: translateY(-2px);
+    border-color: var(--accent-green);
+    box-shadow: 0 8px 24px rgba(137, 223, 0, 0.08);
+}
+
+.before-scenario .phase-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 4rem;
+    min-width: 4rem;
+    height: 4rem;
+    font-size: 1.75rem;
+    color: var(--accent-green);
+    background-color: rgba(137, 223, 0, 0.1);
+    border-radius: 8px;
+}
+
+.before-scenario .phase-content h3 {
+    margin-bottom: 1rem;
+}
+
+.before-scenario .phase-content p {
+    margin-bottom: 0;
+}
+
 /* Flow Input Section */
 .flow-input-section {
     margin: 3rem 0;
@@ -624,7 +670,6 @@ nav {
     background-color: var(--box-bg);
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    text-align: center;
 }
 
 .comparison-cta p {
@@ -662,7 +707,7 @@ nav {
 }
 
 .comparison-table thead {
-    background-color: var(--bg-section);
+    background-color: var(--bg-dark);
 }
 
 .comparison-table th {
@@ -719,6 +764,7 @@ nav {
 /* Quote */
 .quote {
     border-left: 4px solid var(--accent-green);
+    background-color: var(--box-bg);
     padding-left: 2rem;
     margin: 4rem 0;
     font-size: 1.25rem;
@@ -764,6 +810,35 @@ nav {
     color: var(--accent-green);
     font-weight: bold;
     font-size: 1.25rem;
+}
+
+.redefining-grid {
+    gap: 2rem;
+}
+
+.redefining-card {
+    background-color: var(--box-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 2rem;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.redefining-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-green);
+    box-shadow: 0 8px 24px rgba(137, 223, 0, 0.1);
+}
+
+.redefining-card h4 {
+    margin-bottom: 1rem;
+}
+
+.redefining-card p {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--text-secondary);
+    margin: 0;
 }
 
 /* Reactive Art Section */
@@ -817,7 +892,6 @@ nav {
     color: var(--text-secondary);
     max-width: 900px;
     margin: 0 auto 4rem;
-    text-align: center;
 }
 
 .progression-boxes {
@@ -890,20 +964,19 @@ nav {
     }
 }
 
-.audit-trail>.container>p:first-of-type {
+.audit-trail>.container>p {
     font-size: 1.125rem;
     line-height: 1.8;
     color: var(--text-secondary);
     max-width: 900px;
-    margin: 0 auto 4rem;
-    text-align: center;
+    margin: 0 auto 1rem;
 }
 
 .audit-boxes {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 2rem;
-    margin-bottom: 4rem;
+    margin-bottom: 2rem;
 }
 
 .audit-box {
@@ -927,14 +1000,6 @@ nav {
     color: var(--text-secondary);
 }
 
-.conclusion {
-    font-size: 1.125rem;
-    line-height: 1.8;
-    color: var(--text-secondary);
-    max-width: 900px;
-    margin: 4rem auto 0;
-    text-align: center;
-}
 
 /* Footer */
 footer {
@@ -991,7 +1056,6 @@ footer a:hover {
     max-width: 900px;
     margin-left: auto;
     margin-right: auto;
-    text-align: center;
 }
 
 
@@ -1348,11 +1412,25 @@ footer a:hover {
     margin-bottom: 2rem;
 }
 
+.non-goals-split {
+    grid-template-columns: repeat(2, minmax(280px, 420px));
+    justify-content: center;
+}
+
+.non-goals-column {
+    background-color: var(--bg-section);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+
 .non-goals-column p {
     font-size: 1.125rem;
-    line-height: 1.8;
+    line-height: 1.6;
     color: var(--text-secondary);
     margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .non-goals-column p strong {
@@ -1372,7 +1450,7 @@ footer a:hover {
 
 .non-goals-list {
     list-style: none;
-    margin: 1rem 0 2rem 0;
+    margin: 0;
     padding-left: 0;
 }
 
@@ -1392,6 +1470,40 @@ footer a:hover {
     color: var(--accent-green);
     font-weight: bold;
     font-size: 1.25rem;
+}
+
+.technical-background-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.technical-background-intro,
+.technical-background-link {
+    font-size: 1.125rem;
+    line-height: 1.8;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.technical-background-list {
+    background-color: var(--bg-section);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+
+.technical-background-link {
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-color);
+}
+
+@media (max-width: 768px) {
+    .non-goals-split {
+        grid-template-columns: 1fr;
+    }
 }
 
 .coverage-section {
@@ -1533,7 +1645,6 @@ footer a:hover {
     line-height: 1.8;
     color: var(--text-secondary);
     margin-bottom: 2rem;
-    text-align: center;
     max-width: 900px;
     margin-left: auto;
     margin-right: auto;
@@ -1955,18 +2066,78 @@ footer a:hover {
 
 /* Directory Structure Section */
 .directory-structure {
-    padding: 4rem 0;
-    background: var(--bg-section);
+    padding: 5rem 0;
+    background: var(--bg-light);
+}
+
+.directory-structure-header {
+    margin-bottom: 2.5rem;
+}
+
+.directory-structure-header h2 {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-bottom: 2rem;
+    color: var(--text-primary);
+    text-align: center;
+    letter-spacing: var(--letter-spacing-tight);
+}
+
+@media (min-width: 768px) {
+    .directory-structure-header h2 {
+        font-size: 3rem;
+    }
+}
+
+.directory-structure-header .section-intro {
+    font-size: 1.125rem;
+    line-height: 1.8;
+    color: var(--text-secondary);
+    max-width: 900px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.directory-structure-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+    gap: 2rem;
+    align-items: start;
 }
 
 .tree-structure {
-    margin: 2rem 0;
+    margin: 0;
     border-radius: 8px;
-    overflow: hidden;
+}
+
+.tree-structure-card {
+    background: var(--box-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 2rem;
+}
+
+.tree-structure-meta {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.tree-structure-meta h4 {
+    color: var(--text-primary);
+    font-size: 1.25rem;
+    margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+
+.tree-structure-meta p {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1.7;
 }
 
 .tree-structure pre {
-    background: var(--box-bg);
+    background: var(--bg-section);
     border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 2rem;
@@ -1983,9 +2154,14 @@ footer a:hover {
 
 .structure-explanation {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 3rem;
-    margin-top: 2rem;
+    gap: 1.25rem;
+}
+
+.structure-column {
+    background: var(--box-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1.5rem;
 }
 
 .structure-column h4 {
@@ -2060,10 +2236,24 @@ footer a:hover {
     font-style: italic;
 }
 
-@media (max-width: 768px) {
-    .structure-explanation {
+@media (max-width: 1024px) {
+    .directory-structure-layout {
         grid-template-columns: 1fr;
-        gap: 2rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .directory-structure {
+        padding: 4rem 0;
+    }
+
+    .tree-structure-card,
+    .structure-column {
+        padding: 1rem;
+    }
+
+    .tree-structure-meta {
+        padding: 0 0 1rem;
     }
 
     .tree-structure pre {

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -706,6 +706,16 @@ nav {
     min-width: 200px;
 }
 
+.comparison-table a {
+    color: var(--accent-green);
+    text-decoration: none;
+}
+
+.comparison-table a:hover {
+    color: var(--accent-green-hover);
+    text-decoration: underline;
+}
+
 /* Quote */
 .quote {
     border-left: 4px solid var(--accent-green);

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -663,32 +663,63 @@ nav {
     text-decoration: underline;
 }
 
-/* Comparison CTA */
-.comparison-cta {
+/* Next Step CTA */
+.next-step-cta {
     margin-top: 3rem;
-    padding: 1.5rem;
+    padding: 2rem;
     background-color: var(--box-bg);
     border: 1px solid var(--border-color);
     border-radius: 8px;
+    text-align: center;
 }
 
-.comparison-cta p {
+.next-step-cta h3 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 1rem;
+}
+
+.next-step-cta p {
     font-size: 1.125rem;
     line-height: 1.8;
     color: var(--text-secondary);
-    margin: 0;
+    margin: 0 auto;
+    max-width: 720px;
 }
 
-.comparison-cta a {
+.next-step-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.next-step-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0.85rem 1.25rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background-color: var(--bg-section);
     color: var(--accent-green);
     text-decoration: none;
     font-weight: 600;
-    transition: color 0.2s ease;
+    transition: transform 0.2s ease, border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
 }
 
-.comparison-cta a:hover {
+.next-step-link:hover {
     color: var(--accent-green-hover);
-    text-decoration: underline;
+    border-color: var(--accent-green);
+    transform: translateY(-1px);
+}
+
+.next-step-link-primary {
+    background-color: rgba(137, 223, 0, 0.1);
+    border-color: rgba(137, 223, 0, 0.25);
 }
 
 /* Comparison Table */
@@ -711,7 +742,7 @@ nav {
 }
 
 .comparison-table th {
-    padding: 1.25rem;
+    padding: 1.5rem 1.25rem;
     text-align: left;
     font-size: 1rem;
     font-weight: 600;
@@ -720,12 +751,20 @@ nav {
 }
 
 .comparison-table td {
-    padding: 1.25rem;
+    padding: 1.5rem 1.25rem;
     font-size: 0.95rem;
     line-height: 1.7;
     color: var(--text-secondary);
     border-bottom: 1px solid var(--border-color);
     vertical-align: top;
+}
+
+.comparison-table tbody tr:nth-child(odd) {
+    background-color: rgba(137, 223, 0, 0.03);
+}
+
+.comparison-table tbody tr:nth-child(even) {
+    background-color: var(--box-bg);
 }
 
 .comparison-table tbody tr:last-child td {
@@ -984,6 +1023,13 @@ nav {
     border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 2rem;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.audit-box:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-green);
+    box-shadow: 0 8px 24px rgba(137, 223, 0, 0.1);
 }
 
 .audit-box h4 {
@@ -1152,9 +1198,16 @@ footer a:hover {
 }
 
 .workflow-item {
-    margin-bottom: 2rem;
-    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    padding: 1.25rem 1.5rem;
+    background-color: var(--bg-section);
+    border: 1px solid var(--border-color);
     border-left: 3px solid var(--accent-green);
+    border-radius: 0 8px 8px 0;
+}
+
+.workflow-item:last-of-type {
+    margin-bottom: 0;
 }
 
 .workflow-item h4 {
@@ -1232,6 +1285,14 @@ footer a:hover {
     color: var(--text-primary);
     margin-bottom: 0.75rem;
     padding-left: 0.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.commit-item:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
 }
 
 .commit-item code {
@@ -1317,6 +1378,13 @@ footer a:hover {
     border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 2rem;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.shift-item:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-green);
+    box-shadow: 0 8px 24px rgba(137, 223, 0, 0.1);
 }
 
 .shift-item h4 {
@@ -1795,6 +1863,11 @@ footer a:hover {
     margin-top: 2rem;
 }
 
+.reference-grid-balanced {
+    grid-template-columns: repeat(2, minmax(280px, 420px));
+    justify-content: center;
+}
+
 .reference-card {
     background-color: var(--box-bg);
     border: 1px solid var(--border-color);
@@ -1879,6 +1952,27 @@ footer a:hover {
     transition: transform 0.2s ease, margin-left 0.2s ease;
 }
 
+.ai-workflow-section,
+.demo-section,
+.documentation-section,
+.compound-effect {
+    margin-top: 3rem;
+    padding: 2.5rem;
+    background-color: var(--box-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+}
+
+.ai-workflow-section .code-example,
+.demo-section .code-example,
+.documentation-section .commit-list {
+    background-color: var(--bg-section);
+}
+
+.demo-section .benefits-grid {
+    margin-top: 2rem;
+}
+
 .reference-link:hover::after {
     transform: translateX(4px);
     margin-left: 0.75rem;
@@ -1959,6 +2053,18 @@ footer a:hover {
     .benefits-grid,
     .audit-boxes {
         grid-template-columns: 1fr;
+    }
+
+    .reference-grid-balanced {
+        grid-template-columns: 1fr;
+    }
+
+    .next-step-actions {
+        flex-direction: column;
+    }
+
+    .next-step-link {
+        width: 100%;
     }
 }
 

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -905,6 +905,20 @@ nav {
     pointer-events: none;
 }
 
+.progression-section {
+    background-color: var(--bg-section);
+    background-image: radial-gradient(circle at top left, rgba(137, 223, 0, 0.1), transparent 32%), linear-gradient(180deg, rgba(45, 51, 56, 0.96) 0%, rgba(26, 31, 35, 0.96) 100%);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-attachment: scroll;
+}
+
+.progression-section::before {
+    background: linear-gradient(180deg, rgba(26, 31, 35, 0.24) 0%, rgba(26, 31, 35, 0.5) 100%);
+    opacity: 1;
+}
+
 .reactive-art>* {
     position: relative;
     z-index: 1;

--- a/docs/common-questions.html
+++ b/docs/common-questions.html
@@ -393,6 +393,17 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                                 documentation</a>.</p>
                     </div>
                 </div>
+
+                <div class="next-step-cta">
+                    <h3>Continue Evaluating the Workflow</h3>
+                    <p>Watch the short walkthrough next, then dive into the real prompts, proofs, and validation
+                        artifacts behind the workflow.</p>
+                    <div class="next-step-actions">
+                        <a class="next-step-link next-step-link-primary" href="video-overview.html">Watch the Overview
+                            Video</a>
+                        <a class="next-step-link" href="reference-materials.html">Browse Reference Materials</a>
+                    </div>
+                </div>
             </div>
         </section>
     </main>

--- a/docs/common-questions.html
+++ b/docs/common-questions.html
@@ -96,7 +96,7 @@
 
                 <div class="non-goals-box">
                     <h3>Non-Goals Defined Clear Boundaries</h3>
-                    <div class="non-goals-content">
+                    <div class="non-goals-content non-goals-split">
                         <div class="non-goals-column">
                             <p><strong>Explicitly Out of Scope:</strong></p>
                             <ul class="non-goals-list">
@@ -375,11 +375,11 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
 
                 <div class="non-goals-box">
                     <h3>Technical Background</h3>
-                    <div class="non-goals-content">
-                        <p>This verification technique was shared by Lada Kesseler at AI Native Dev Con Fall 2025 as a
+                    <div class="non-goals-content technical-background-content">
+                        <p class="technical-background-intro">This verification technique was shared by Lada Kesseler at AI Native Dev Con Fall 2025 as a
                             practical solution for detecting context rot in production AI workflows. The technique
                             provides:</p>
-                        <ul class="non-goals-list">
+                        <ul class="non-goals-list technical-background-list">
                             <li><strong>Immediate feedback:</strong> Visual confirmation that instructions are being
                                 followed</li>
                             <li><strong>Low overhead:</strong> Minimal token cost (1-2 tokens per response)</li>
@@ -387,7 +387,7 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                             <li><strong>Failure detection:</strong> Absence of marker immediately signals instruction
                                 loss</li>
                         </ul>
-                        <p style="margin-top: 1rem;">For detailed research and technical information, see the <a
+                        <p class="technical-background-link">For detailed research and technical information, see the <a
                                 href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/docs/emoji-context-verification-research.md"
                                 target="_blank" rel="noopener noreferrer">context verification research
                                 documentation</a>.</p>

--- a/docs/common-questions.html
+++ b/docs/common-questions.html
@@ -28,7 +28,8 @@
                         adaptability. This evidence-based FAQ addresses common objections to Liatrio's Spec-Driven
                         Development (SDD) using a concrete example: implementing a cspell pre-commit hook for
                         spell-checking. By analyzing specifications, task lists, proof artifacts, and validation
-                        reports, we demonstrate how well-executed SDD works in practice.</p>
+                        reports, we demonstrate how well-executed SDD works in practice. You can inspect the full
+                        example in <a href="reference-materials.html">Reference Materials</a>.</p>
                     <p>It also highlights something easy to miss: <em>SDD keeps its method visible</em>. The workflow is not
                         hidden behind a product layer, allowing teams to inspect the prompts and understand the
                         patterns that drive the workflow. This accessibility enables teams to improve their skills
@@ -43,8 +44,8 @@
                 <h2>Does Spec-Driven Development Add Unnecessary Overhead?</h2>
                 <p class="section-intro">Structured processes often face criticism for introducing bureaucratic
                     overhead. However, the cspell hook implementation proves that SDD structure is an investment, not a
-                    cost. By mandating upfront clarity, it prevents ambiguity and rework—the true sources of
-                    delay—ultimately increasing development velocity.</p>
+                    cost. By forcing the hardest thinking into the first two steps when correction is cheapest, it
+                    prevents ambiguity and rework. These are the true sources of delay. Mandating upfront clarity ultimately increases development velocity.</p>
 
                 <div class="objection-content-grid">
                     <div class="objection-card">
@@ -57,10 +58,10 @@
                                     stroke-linecap="round" stroke-linejoin="round" />
                             </svg>
                         </div>
-                        <h4>Upfront Planning Prevents Waste</h4>
-                        <p>The specification clearly established Goals and Non-Goals, defining what's out of scope. This
-                            protected the team from scope creep and unexpected requirements, concentrating effort
-                            exclusively on agreed-upon value.</p>
+                        <h4>Upfront Planning Prevents Costly Rework</h4>
+                        <p>The specification clearly established Goals and Non-Goals, defining what's out of scope.
+                            That early clarity protected the team from scope creep and unexpected requirements, when it
+                            was still cheap to make adjustments.</p>
                     </div>
 
                     <div class="objection-card">
@@ -73,8 +74,8 @@
                         </div>
                         <h4>Structured Work Creates Velocity</h4>
                         <p>Git history shows implementation took under 6 minutes—from first commit (09:57:02) to final
-                            commit (10:02:41). This remarkable speed was enabled by a clear plan breaking work into four
-                            distinct tasks.</p>
+                            commit (10:02:41). That speed was enabled by Step 2 turning the approved spec into four
+                            distinct tasks before implementation began.</p>
                     </div>
 
                     <div class="objection-card">

--- a/docs/common-questions.html
+++ b/docs/common-questions.html
@@ -311,6 +311,78 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
             </div>
         </section>
 
+        <section class="phases-detailed">
+            <div class="container">
+                <h2>Are Specs, Tasks, and Proofs Supposed To Live in the Repo Forever?</h2>
+                <p class="section-intro">No. In SDD, these artifacts are process scaffolding for an implementation
+                    loop, not living documentation that must stay perfectly synchronized forever. Their job is to help a
+                    human and an AI align on the work, verify progress, and make the reasoning process explicit while
+                    the feature is being built.</p>
+
+                <div class="objection-content-grid">
+                    <div class="objection-card">
+                        <div class="objection-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                <path d="M12 2L2 7l10 5 10-5-10-5z" stroke="currentColor" stroke-width="2"
+                                    stroke-linecap="round" stroke-linejoin="round" />
+                                <path d="M2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" stroke-width="2"
+                                    stroke-linecap="round" stroke-linejoin="round" />
+                            </svg>
+                        </div>
+                        <h4>Process Artifacts, Not Product Docs</h4>
+                        <p>Specs, tasks, proofs, and validation reports exist to guide the current implementation loop.
+                            Once that loop is complete, the durable source of truth becomes the code and tests.</p>
+                    </div>
+
+                    <div class="objection-card">
+                        <div class="objection-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                            </svg>
+                        </div>
+                        <h4>Storage and Retention Are Flexible</h4>
+                        <p>Some teams keep artifacts in <code>docs/specs/</code>, some archive them, and some map them
+                            to Jira, GitHub issues, or other systems. SDD stays intentionally unopinionated so teams can
+                            manage context the way that fits their environment.</p>
+                    </div>
+
+                    <div class="objection-card">
+                        <div class="objection-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                <path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path d="M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
+                                    stroke="currentColor" stroke-width="2" />
+                            </svg>
+                        </div>
+                        <h4>They Still Matter After the Run</h4>
+                        <p>Even when they are not maintained forever, these artifacts still provide value as an audit
+                            trail and a teaching surface that shows how the work was framed and verified.</p>
+                    </div>
+                </div>
+
+                <div class="example-box">
+                    <h3>How To Think About PR Feedback</h3>
+                    <h4>Implementation Feedback</h4>
+                    <p>Feedback like "use a different test structure" or "refactor this code path" stays inside the
+                        current implementation and review loop. The original artifacts already did their job by getting
+                        the work to a reviewable state.</p>
+                    <h4>Directional Feedback</h4>
+                    <p>Feedback like "this should use a different technology" or "the scope should be different"
+                        signals that the earlier framing was off. That usually means going back upstream, clarifying the
+                        direction, and starting a new spec for a new implementation loop.</p>
+                    <p>You can think of specs and proofs like the recipe notes and test batches used to bake a tray of
+                        cookies. They help you get the current batch right, but once the batch is baked, the next major
+                        change is usually a new batch, not an edit to the old dough.</p>
+                </div>
+            </div>
+        </section>
+
         <!-- Context Verification Question -->
         <section class="phases-detailed" id="why-do-ai-responses-start-with-emoji-markers">
             <div class="container">

--- a/docs/common-questions.html
+++ b/docs/common-questions.html
@@ -29,6 +29,10 @@
                         Development (SDD) using a concrete example: implementing a cspell pre-commit hook for
                         spell-checking. By analyzing specifications, task lists, proof artifacts, and validation
                         reports, we demonstrate how well-executed SDD works in practice.</p>
+                    <p>It also highlights something easy to miss: <em>SDD keeps its method visible</em>. The workflow is not
+                        hidden behind a product layer, allowing teams to inspect the prompts and understand the
+                        patterns that drive the workflow. This accessibility enables teams to improve their skills
+                        with AI as they learn SDD.</p>
                 </div>
             </div>
         </section>
@@ -274,6 +278,9 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                     <p>SDD provides a robust framework that enhances clarity, guarantees verifiability, and gracefully
                         accommodates change. The initial investment in structured planning and documentation delivers
                         more predictable, successful outcomes with reduced rework and increased stakeholder confidence.
+                        Because the workflow is exposed in readable prompts and artifacts, it also helps engineers learn
+                        the patterns of effective AI-assisted development instead of treating them as hidden product
+                        behavior.
                     </p>
 
                     <div class="metrics-grid">
@@ -297,7 +304,7 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                     <blockquote class="quote">
                         <strong>Key Takeaway:</strong> The evidence from this real-world implementation demonstrates
                         that SDD's structured approach is not overhead—it's an investment that pays dividends through
-                        clarity, velocity, and quality assurance.
+                        clarity, velocity, quality assurance, and a more teachable way of working with AI.
                     </blockquote>
                 </div>
             </div>
@@ -359,7 +366,9 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                             <code>SDD1️⃣ I'll help you generate a specification...</code> or
                             <code>SDD3️⃣ Let me start implementing task 1.0...</code>. This is expected behavior and
                             indicates the verification system is working correctly. The markers add minimal overhead
-                            (1-2 tokens) while providing immediate visual feedback.
+                            (1-2 tokens) while providing immediate visual feedback. They also model a broader SDD
+                            principle: effective AI workflows should make important operating logic explicit and easy to
+                            inspect.
                         </p>
                     </div>
                 </div>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -201,7 +201,6 @@
                     structure, but how much new product or process it asks engineers to adopt. Liatrio's prompts aim to
                     provide structure in a repo-native form: readable markdown, editable conventions, and a workflow
                     that can sit on top of existing tools rather than replace them.</p>
-                <br>
                 <p>This pattern extends beyond Kiro, SpecKit, and Taskmaster. Other spec-driven frameworks such as
                     Tessl and BMAD also add structure by introducing a larger system around the developer: more
                     tooling, more workflow machinery, and more framework-specific concepts to absorb. Liatrio's SDD
@@ -209,8 +208,15 @@
                     can inspect it, adapt it, and internalize better AI collaboration patterns instead of depending on
                     a mediated system.</p>
 
-                <div class="comparison-cta">
-                    <p><a href="index.html">← Back to the Playbook</a></p>
+                <div class="next-step-cta">
+                    <h3>See What This Means for Developers</h3>
+                    <p>After comparing the operating models, look at how SDD changes implementation work in practice
+                        and how teams can address common concerns about the workflow.</p>
+                    <div class="next-step-actions">
+                        <a class="next-step-link next-step-link-primary" href="developer-experience.html">Explore
+                            Developer Experience</a>
+                        <a class="next-step-link" href="common-questions.html">Read Common Questions</a>
+                    </div>
                 </div>
             </div>
         </section>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -22,12 +22,14 @@
         <!-- Hero Section -->
         <section class="hero">
             <div class="container">
-                <h1>Why Not Other Structured Development Tools?</h1>
+                <h1>Comparing SDD to Other Structured Development Tools</h1>
                 <div class="hero-content">
-                    <p>Other structured development tools like Kiro, SpecKit, and Taskmaster offer structured approaches
-                        to AI-assisted development, but they require installation, configuration, and learning new
-                        workflows. Here's why Liatrio's 4 transparent prompts are a better fit for day-to-day
-                        development work.</p>
+                    <p>Kiro, SpecKit, and Taskmaster each add structure to AI-assisted development, but they do so
+                        through very different operating models. This page compares Liatrio's four repo-local SDD
+                        prompts with those tools, with a focus on setup, workflow fit, and day-to-day adoption cost.</p>
+                    <p>A second distinction matters just as much: SDD exposes its logic in plain markdown, so teams can
+                        learn the patterns behind effective AI collaboration instead of depending on a product to hide
+                        or mediate them.</p>
                 </div>
             </div>
         </section>
@@ -36,8 +38,10 @@
         <section class="phases-detailed">
             <div class="container">
                 <h2>Comparison: Liatrio's Prompts vs. Other Structured Development Tools</h2>
-                <p class="section-intro">How do Liatrio's prompts compare to other structured development tools? Here's
-                    a side-by-side look at the key differences.</p>
+                <p class="section-intro">The table below compares Liatrio's prompts with three other structured
+                    development approaches. The emphasis is less on feature lists and more on the practical cost of
+                    adopting each system inside an existing engineering workflow, including whether the workflow itself
+                    is something engineers can inspect and learn from.</p>
 
                 <div class="comparison-table-wrapper">
                     <table class="comparison-table">
@@ -45,65 +49,110 @@
                             <tr>
                                 <th>Feature</th>
                                 <th>Liatrio's SDD Prompts</th>
-                                <th>Kiro / SpecKit / Taskmaster</th>
+                                <th>Kiro</th>
+                                <th>SpecKit</th>
+                                <th>Taskmaster</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
                                 <td><strong>Setup & Installation</strong></td>
-                                <td>✅ Just 4 markdown files—no installation</td>
-                                <td>❌ Kiro: Requires downloading IDE app. SpecKit: Requires installation and
-                                    configuration. Taskmaster: Requires installation and setup.</td>
+                                <td>✅ <a href="https://github.com/liatrio-labs/spec-driven-workflow">Four markdown files
+                                        added as prompts within your existing workflow</a></td>
+                                <td>❌ <a href="https://kiro.dev/downloads/">Requires installing Kiro, signing in, and
+                                        learning its product-specific workflow model</a>
+                                </td>
+                                <td>❌ <a href="https://github.com/github/spec-kit">Requires the Specify CLI, generated
+                                        agent command files, and adoption of a large multi-step workflow</a></td>
+                                <td>❌ <a
+                                        href="https://docs.task-master.dev/getting-started/quick-start/installation#option-1-mcp-recommended">MCP
+                                        or CLI setup, plus model/API configuration, project initialization, and a
+                                        PRD-to-task pipeline</a></td>
                             </tr>
                             <tr>
                                 <td><strong>Editor/IDE Dependency</strong></td>
-                                <td>✅ Works with any editor (VS Code, Cursor, etc.)</td>
-                                <td>❌ Kiro: Requires switching to Kiro IDE. SpecKit/Taskmaster: Work within existing
-                                    editors but require specific setup.</td>
+                                <td>✅ Works in editors that support prompts or slash commands</td>
+                                <td>❌ Structured workflow assumes the Kiro IDE as the primary environment</td>
+                                <td>⚠️ Runs in existing editors through generated agent commands</td>
+                                <td>⚠️ Works in existing editors through CLI or MCP integration</td>
                             </tr>
                             <tr>
                                 <td><strong>AI Assistant Compatibility</strong></td>
-                                <td>✅ Works with any AI assistant (Claude, GPT, Gemini, etc.)</td>
-                                <td>❌ Kiro: Built-in AI. SpecKit: Works with GitHub Copilot, Claude Code, Gemini CLI.
-                                    Taskmaster: Works with Claude, Cursor, etc.</td>
+                                <td>✅ Works with assistants that support custom prompts or slash commands</td>
+                                <td>⚠️ Uses Kiro's built-in agent experience, model options, and product-specific modes
+                                </td>
+                                <td>⚠️ Works through supported agent integrations and slash commands</td>
+                                <td>⚠️ Works through CLI or MCP integrations plus model-provider and agent setup</td>
                             </tr>
                             <tr>
                                 <td><strong>Learning Curve</strong></td>
-                                <td>✅ Just read markdown prompts—no new concepts</td>
-                                <td>❌ Kiro: Learn new IDE. SpecKit: Learn command system (`/speckit.specify`,
-                                    `/speckit.plan`, etc.). Taskmaster: Learn task management system.</td>
+                                <td>✅ Uses a guided four-prompt workflow layered onto your existing workflow</td>
+                                <td>❌ Requires learning Kiro's broader vocabulary and workflow model (`specs`,
+                                    `steering`, `hooks`, `powers`, `autopilot`, `vibe` vs `spec`, etc.)</td>
+                                <td>❌ Requires learning a large `constitution` → `specify` → `clarify` →
+                                    `plan` → `tasks` → `implement` methodology</td>
+                                <td>❌ Requires learning Taskmaster's broader orchestration model: PRDs, task graphs,
+                                    subtasks, dependencies, statuses, and optional autopilot/TDD workflows</td>
                             </tr>
                             <tr>
                                 <td><strong>Transparency</strong></td>
-                                <td>✅ Every prompt is readable markdown—no black boxes</td>
-                                <td>❌ Tool logic is hidden in codebases. Can't easily see or modify how they work.</td>
+                                <td>✅ Prompts are plain markdown, so the workflow logic is directly readable, editable,
+                                    and teachable</td>
+                                <td>⚠️ Some files are editable, but core behavior, modes, and workflow concepts live in
+                                    the product</td>
+                                <td>⚠️ Workflow files and templates are published on GitHub, but much of the method is
+                                    still experienced through its larger system</td>
+                                <td>⚠️ Open source, but much of the behavior lives in JS packages, configs, and task
+                                    state data</td>
                             </tr>
                             <tr>
                                 <td><strong>Flexibility</strong></td>
-                                <td>✅ Edit prompts to fit your project/style/company guidelines</td>
-                                <td>❌ Limited customization. Must work within tool's structure and constraints.</td>
+                                <td>✅ Prompt text can be edited to match team or project conventions</td>
+                                <td>⚠️ Steering files, hooks, and modes are configurable within Kiro's product model
+                                </td>
+                                <td>⚠️ Templates can be adapted, but the workflow, artifacts, and process vocabulary
+                                    stay highly prescriptive</td>
+                                <td>⚠️ Models, prompts, tasks, tags, and execution modes can be configured within its
+                                    orchestration system</td>
                             </tr>
                             <tr>
                                 <td><strong>File Structure</strong></td>
-                                <td>✅ Simple <code>docs/specs/</code> that doesn't pollute repo</td>
-                                <td>❌ Kiro: IDE-specific files. SpecKit: Creates <code>.specify/</code> directory
-                                    structure. Taskmaster: Task management files.</td>
+                                <td>✅ Uses a repository-level <code>docs/specs/</code> structure but can be easily adapted
+                                    to any directory structure</td>
+                                <td>⚠️ Stores project-specific files in <code>.kiro</code> alongside multiple product
+                                    concepts and configs</td>
+                                <td>❌ Creates a <code>.specify/</code> directory, agent-specific command files, and
+                                    multiple generated planning artifacts</td>
+                                <td>❌ Stores PRDs, config, state, task graphs, and generated artifacts in
+                                    <code>.taskmaster/</code></td>
                             </tr>
                             <tr>
                                 <td><strong>Workflow Integration</strong></td>
-                                <td>✅ Fits into your existing workflow—no context switching</td>
-                                <td>❌ Kiro: Requires switching IDEs. SpecKit: Requires using specific commands.
-                                    Taskmaster: Requires managing tasks through tool.</td>
+                                <td>✅ Adds structure without replacing repo-local development workflows</td>
+                                <td>❌ Best fit when teams are willing to adopt Kiro as the primary workspace and
+                                    operating model</td>
+                                <td>❌ Can run in an existing repo, but expects teams to adopt its full process and
+                                    artifact model</td>
+                                <td>❌ Adds a separate planning, execution, and tracking layer on top of normal
+                                    engineering work</td>
                             </tr>
                             <tr>
                                 <td><strong>Speed</strong></td>
-                                <td>✅ Complete feature in minutes (example: &lt;15 min)</td>
-                                <td>⚠️ Varies by tool, but requires learning and setup overhead</td>
+                                <td>✅ Minimal setup overhead once prompts are installed</td>
+                                <td>❌ Front-loaded overhead is high because teams must learn the product model before
+                                    moving quickly</td>
+                                <td>❌ Front-loaded overhead is high because the workflow generates and coordinates many
+                                    artifacts</td>
+                                <td>❌ Front-loaded overhead is high because useful adoption requires creating and
+                                    maintaining the task system</td>
                             </tr>
                             <tr>
                                 <td><strong>Cost</strong></td>
-                                <td>✅ Free—just markdown files</td>
-                                <td>✅ All are open source, but require time investment to learn</td>
+                                <td>✅ Markdown files are free to use</td>
+                                <td>⚠️ Free tier available, but usage is managed through sign-in, credits, and paid
+                                    usage tiers</td>
+                                <td>✅ Open source</td>
+                                <td>⚠️ Open source, with limits on some commercial use cases</td>
                             </tr>
                         </tbody>
                     </table>
@@ -115,23 +164,21 @@
         <section class="reactive-art">
             <div class="container">
                 <div class="installation-highlight">
-                    <h2>Getting Started Is Simple</h2>
-                    <p>While other tools require complex installation and configuration, the SDD workflow prompts can be
-                        installed
+                    <h2>Repo-Native Setup</h2>
+                    <p>The SDD workflow prompts can be installed
                         in any AI assistant in seconds using the <a
                             href="https://github.com/liatrio-labs/slash-command-manager" target="_blank"
                             rel="noopener noreferrer">slash-command-manager</a>. This open-source tool from Liatrio
-                        makes it
-                        straightforward
+                        makes it straightforward
                         to add the prompts as slash commands in VS Code, Cursor, Claude Code, and many other AI tools
-                        that
-                        support
-                        custom commands.</p>
-                    <p>No complex setup, no configuration files, no learning curve—just install the prompts and start
-                        using
-                        them immediately in your existing workflow. See the <a
+                        that support custom commands.</p>
+                    <p>Because the workflow is plain markdown, teams can adopt it without taking on a new IDE, a
+                        generated artifact model, or a separate task-orchestration system. See the <a
                             href="https://github.com/liatrio-labs/spec-driven-workflow#tldr--quickstart" target="_blank"
                             rel="noopener noreferrer">installation instructions in the README</a> to get started.</p>
+                    <p>That same simplicity also makes SDD useful as a teaching tool: engineers can read the prompts,
+                        understand the workflow patterns they encode, and reuse those patterns when working with AI in
+                        other contexts.</p>
                 </div>
             </div>
         </section>
@@ -140,11 +187,13 @@
         <section class="phases-detailed">
             <div class="container">
                 <h2>The Bottom Line</h2>
-                <p>For day-to-day development work in enterprise companies, Liatrio's 4 prompts provide the structure
-                    and rigor you need without requiring new tools, installation, or learning curves. They're
-                    transparent, flexible, and designed to fit into your existing workflow—not replace it. Perfect for
-                    developers who want structured AI-assisted development without the overhead of switching tools or
-                    learning new systems.</p>
+                <p>For teams working in existing enterprise codebases, the main tradeoff is not whether a tool offers
+                    structure, but how much new product or process it asks engineers to adopt. Liatrio's prompts aim to
+                    provide structure in a repo-native form: readable markdown, editable conventions, and a workflow
+                    that can sit on top of existing tools rather than replace them.</p>
+                <p>That visibility is part of the value. SDD is designed not only to help teams use AI effectively, but
+                    to help engineers learn how effective AI-assisted engineering works by making the method itself easy
+                    to inspect, discuss, and adapt.</p>
 
                 <div class="comparison-cta">
                     <p><a href="index.html">← Back to the Playbook</a></p>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -57,15 +57,18 @@
                         <tbody>
                             <tr>
                                 <td><strong>Setup & Installation</strong></td>
-                                <td>✅ <a href="https://github.com/liatrio-labs/spec-driven-workflow">Four markdown files
+                                <td>✅ <a href="https://github.com/liatrio-labs/spec-driven-workflow" target="_blank"
+                                        rel="noopener noreferrer">Four markdown files
                                         added as prompts within your existing workflow</a></td>
-                                <td>❌ <a href="https://kiro.dev/downloads/">Requires installing Kiro, signing in, and
+                                <td>❌ <a href="https://kiro.dev/downloads/" target="_blank"
+                                        rel="noopener noreferrer">Requires installing Kiro, signing in, and
                                         learning its product-specific workflow model</a>
                                 </td>
-                                <td>❌ <a href="https://github.com/github/spec-kit">Requires the Specify CLI, generated
+                                <td>❌ <a href="https://github.com/github/spec-kit" target="_blank"
+                                        rel="noopener noreferrer">Requires the Specify CLI, generated
                                         agent command files, and adoption of a large multi-step workflow</a></td>
-                                <td>❌ <a
-                                        href="https://docs.task-master.dev/getting-started/quick-start/installation#option-1-mcp-recommended">MCP
+                                <td>❌ <a href="https://docs.task-master.dev/getting-started/quick-start/installation#option-1-mcp-recommended"
+                                        target="_blank" rel="noopener noreferrer">MCP
                                         or CLI setup, plus model/API configuration, project initialization, and a
                                         PRD-to-task pipeline</a></td>
                             </tr>
@@ -87,10 +90,15 @@
                             <tr>
                                 <td><strong>Learning Curve</strong></td>
                                 <td>✅ Uses a guided four-prompt workflow layered onto your existing workflow</td>
-                                <td>❌ Requires learning Kiro's broader vocabulary and workflow model (`specs`,
-                                    `steering`, `hooks`, `powers`, `autopilot`, `vibe` vs `spec`, etc.)</td>
-                                <td>❌ Requires learning a large `constitution` → `specify` → `clarify` →
-                                    `plan` → `tasks` → `implement` methodology</td>
+                                <td>❌ Requires learning Kiro's broader vocabulary and workflow model
+                                    (<code>specs</code>,
+                                    <code>steering</code>, <code>hooks</code>, <code>powers</code>,
+                                    <code>autopilot</code>, <code>vibe</code> vs <code>spec</code>, etc.)
+                                </td>
+                                <td>❌ Requires learning a large <code>constitution</code> → <code>specify</code> →
+                                    <code>clarify</code> → <code>plan</code> → <code>tasks</code> →
+                                    <code>implement</code> methodology
+                                </td>
                                 <td>❌ Requires learning Taskmaster's broader orchestration model: PRDs, task graphs,
                                     subtasks, dependencies, statuses, and optional autopilot/TDD workflows</td>
                             </tr>
@@ -117,14 +125,16 @@
                             </tr>
                             <tr>
                                 <td><strong>File Structure</strong></td>
-                                <td>✅ Uses a repository-level <code>docs/specs/</code> structure but can be easily adapted
+                                <td>✅ Uses a repository-level <code>docs/specs/</code> structure but can be easily
+                                    adapted
                                     to any directory structure</td>
                                 <td>⚠️ Stores project-specific files in <code>.kiro</code> alongside multiple product
                                     concepts and configs</td>
                                 <td>❌ Creates a <code>.specify/</code> directory, agent-specific command files, and
                                     multiple generated planning artifacts</td>
                                 <td>❌ Stores PRDs, config, state, task graphs, and generated artifacts in
-                                    <code>.taskmaster/</code></td>
+                                    <code>.taskmaster/</code>
+                                </td>
                             </tr>
                             <tr>
                                 <td><strong>Workflow Integration</strong></td>
@@ -191,9 +201,13 @@
                     structure, but how much new product or process it asks engineers to adopt. Liatrio's prompts aim to
                     provide structure in a repo-native form: readable markdown, editable conventions, and a workflow
                     that can sit on top of existing tools rather than replace them.</p>
-                <p>That visibility is part of the value. SDD is designed not only to help teams use AI effectively, but
-                    to help engineers learn how effective AI-assisted engineering works by making the method itself easy
-                    to inspect, discuss, and adapt.</p>
+                <br>
+                <p>This pattern extends beyond Kiro, SpecKit, and Taskmaster. Other spec-driven frameworks such as
+                    Tessl and BMAD also add structure by introducing a larger system around the developer: more
+                    tooling, more workflow machinery, and more framework-specific concepts to absorb. Liatrio's SDD
+                    prompts are intentionally different. They expose the workflow logic directly in markdown, so teams
+                    can inspect it, adapt it, and internalize better AI collaboration patterns instead of depending on
+                    a mediated system.</p>
 
                 <div class="comparison-cta">
                     <p><a href="index.html">← Back to the Playbook</a></p>

--- a/docs/developer-experience.html
+++ b/docs/developer-experience.html
@@ -32,6 +32,9 @@
                         impact Liatrio's workflow has on developer experience. We'll first explore the traditional
                         manual approach to establish a baseline, then reveal how AI assistance transforms the entire
                         development lifecycle from hours of toil into minutes of strategic oversight.</p>
+                    <p>Just as importantly, SDD keeps the workflow logic visible. The prompts, specs, tasks, proofs,
+                        and validation artifacts make the method readable, so teams can learn how to guide AI well
+                        instead of relying on hidden product behavior.</p>
                 </div>
             </div>
         </section>
@@ -147,6 +150,8 @@
                     improvement. Developers transition from manual implementers to strategic directors, providing intent
                     via clear specifications while AI agents handle tactical execution. This section explores the key
                     pillars: intelligent asset generation, proactive quality control, and self-documenting processes.
+                    The transparency of the workflow ensures engineers learn how to scope
+                    work, direct AI, and validate results as they follow the steps.
                 </p>
 
                 <div class="ai-workflow-section">
@@ -305,6 +310,11 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                             nature of work itself. This shift from manual toil to strategic oversight is the cornerstone
                             of modern, high-performance engineering culture.</p>
                     </div>
+                    <div class="shift-item">
+                        <h4>Teachable AI Collaboration</h4>
+                        <p>Because SDD exposes the workflow in readable prompts and artifacts, developers can study the
+                            method itself and improve how they interact with AI over time.</p>
+                    </div>
                 </div>
             </div>
         </section>
@@ -334,6 +344,11 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                         <p>Developers evolve from manual laborers bogged down by repetitive tasks to strategic overseers
                             who direct high-level goals and validate results.</p>
                     </div>
+                    <div class="benefits-column">
+                        <h4>Visible Working Method</h4>
+                        <p>The prompts and artifacts make effective AI-assisted engineering visible, which helps
+                            teams build shared habits and judgment instead of depending on hidden workflow logic.</p>
+                    </div>
                 </div>
             </div>
         </section>
@@ -345,7 +360,8 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                 <p>As organizations seek to maximize engineering effectiveness, AI-assisted, spec-driven workflows are
                     poised to become the new standard. This approach doesn't just improve existing processes—it
                     fundamentally reimagines what's possible when human expertise is amplified by intelligent
-                    automation.</p>
+                    automation. The critical advantage of SDD is that it exposes this operating model in a form teams
+                    can read, discuss, and adapt.</p>
 
                 <div class="progression-boxes">
                     <div class="progression-box">

--- a/docs/developer-experience.html
+++ b/docs/developer-experience.html
@@ -384,6 +384,17 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                     our most valuable resource to focus on what truly matters: solving complex problems and delivering
                     exceptional value to customers.
                 </blockquote>
+
+                <div class="next-step-cta">
+                    <h3>Address the Practical Questions</h3>
+                    <p>Next, review the most common objections teams raise about SDD, then watch the short overview of
+                        the workflow end to end.</p>
+                    <div class="next-step-actions">
+                        <a class="next-step-link next-step-link-primary" href="common-questions.html">Read Common
+                            Questions</a>
+                        <a class="next-step-link" href="video-overview.html">Watch the Overview Video</a>
+                    </div>
+                </div>
             </div>
         </section>
     </main>

--- a/docs/developer-experience.html
+++ b/docs/developer-experience.html
@@ -40,7 +40,7 @@
         </section>
 
         <!-- Before Scenario Section -->
-        <section class="phases-detailed">
+        <section class="phases-detailed before-scenario">
             <div class="container">
                 <h2>The "Before" Scenario: A Developer's Manual Toil</h2>
                 <p class="section-intro">To appreciate the efficiency gains of AI-assisted workflows, we must first
@@ -320,7 +320,7 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
         </section>
 
         <!-- Redefining Section -->
-        <section class="phases-detailed">
+        <section class="phases-detailed redefining-experience">
             <div class="container">
                 <h2>Redefining the Developer Experience</h2>
                 <p class="section-intro">This case study demonstrates a fundamental transformation of developer
@@ -328,23 +328,23 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                     findings are clear and compelling, pointing toward a new standard for high-performance software
                     engineering.</p>
 
-                <div class="benefits-grid">
-                    <div class="benefits-column">
+                <div class="benefits-grid redefining-grid">
+                    <div class="benefits-column redefining-card">
                         <h4>Radical Speed Improvements</h4>
                         <p>Implementation time for standard features reduced from hours to minutes, enabling
                             unprecedented development velocity and faster time-to-market for new capabilities.</p>
                     </div>
-                    <div class="benefits-column">
+                    <div class="benefits-column redefining-card">
                         <h4>Embedded Quality & Consistency</h4>
                         <p>Automated gates prevent errors and enforce standards by default, eliminating inconsistencies
                             and reducing technical debt across the entire codebase.</p>
                     </div>
-                    <div class="benefits-column">
+                    <div class="benefits-column redefining-card">
                         <h4>Transformed Developer Role</h4>
                         <p>Developers evolve from manual laborers bogged down by repetitive tasks to strategic overseers
                             who direct high-level goals and validate results.</p>
                     </div>
-                    <div class="benefits-column">
+                    <div class="benefits-column redefining-card">
                         <h4>Visible Working Method</h4>
                         <p>The prompts and artifacts make effective AI-assisted engineering visible, which helps
                             teams build shared habits and judgment instead of depending on hidden workflow logic.</p>

--- a/docs/developer-experience.html
+++ b/docs/developer-experience.html
@@ -29,9 +29,10 @@
                         Development (SDD) augmented by AI. By combining rigorous upfront specifications with AI-driven
                         execution, teams achieve unprecedented velocity without sacrificing quality or consistency.</p>
                     <p>Using a real-world case study—implementing a pre-commit spell checker—we demonstrate the profound
-                        impact Liatrio's workflow has on developer experience. We'll first explore the traditional
-                        manual approach to establish a baseline, then reveal how AI assistance transforms the entire
-                        development lifecycle from hours of toil into minutes of strategic oversight.</p>
+                        impact Liatrio's workflow has on developer experience. You can inspect the full cspell example
+                        in <a href="reference-materials.html">Reference Materials</a>. We'll first explore the
+                        traditional manual approach to establish a baseline, then reveal how AI assistance transforms
+                        the entire development lifecycle from hours of toil into minutes of strategic oversight.</p>
                     <p>Just as importantly, SDD keeps the workflow logic visible. The prompts, specs, tasks, proofs,
                         and validation artifacts make the method readable, so teams can learn how to guide AI well
                         instead of relying on hidden product behavior.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -415,6 +415,17 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="next-step-cta">
+                    <h3>Ready to Explore the Workflow Further?</h3>
+                    <p>Start with how SDD compares to other structured development approaches, then see how the
+                        workflow changes day-to-day developer experience.</p>
+                    <div class="next-step-actions">
+                        <a class="next-step-link next-step-link-primary" href="comparison.html">View the
+                            Comparison</a>
+                        <a class="next-step-link" href="developer-experience.html">Explore Developer Experience</a>
+                    </div>
+                </div>
             </div>
         </section>
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,10 +79,13 @@
         <section class="phases-detailed">
             <div class="container">
                 <h2>The Four Steps</h2>
-                <p class="section-intro">One person runs through these 4 prompts sequentially with an AI assistant. The
-                    example described on this site took less than 15 minutes from start to finish. Because the prompts
-                    are readable, the workflow also doubles as a guide for learning how to scope work, guide AI, and
-                    verify results more effectively.</p>
+                <p class="section-intro">One person runs through these 4 prompts sequentially with an AI assistant. In
+                    the <a href="reference-materials.html">cspell pre-commit hook example</a> featured across this
+                    site, the end-to-end workflow took less than 15 minutes from start to finish. The highest-leverage
+                    work happens in Step 1 and Step 2: when the spec is clear and the task plan is concrete,
+                    implementation and validation are far more likely to run smoothly without human rescue. Because the
+                    prompts are readable, the workflow also doubles as a guide for learning how to scope work, guide
+                    AI, and verify results more effectively.</p>
 
                 <div class="phases-grid">
                     <div class="phase-card">
@@ -91,10 +94,11 @@
                             <h3>Specification</h3>
                         </div>
                         <div class="phase-card-content">
-                            <p><strong>Focus:</strong> Transform your flow input into a structured specification with
-                                clear boundaries and functional requirements.</p>
+                            <p><strong>Focus:</strong> Lock down scope, intent, and success criteria before any code is
+                                written.</p>
                             <p><strong>What It Does:</strong> The prompt validates scope (too large/too small/just
-                                right), asks clarifying questions, and generates a specification document.</p>
+                                right), resolves ambiguous context, and generates a specification document with clear
+                                boundaries.</p>
                             <p><strong>Output:</strong> A markdown spec file in
                                 <code>docs/specs/[NN]-spec-[feature-name]/</code>
                             </p>
@@ -110,10 +114,11 @@
                             <h3>Task Breakdown</h3>
                         </div>
                         <div class="phase-card-content">
-                            <p><strong>Focus:</strong> Break the specification into actionable tasks with demo criteria
-                                and proof artifacts.</p>
+                            <p><strong>Focus:</strong> Turn the approved spec into an executable plan with demo
+                                criteria and proof artifacts.</p>
                             <p><strong>What It Does:</strong> Analyzes the spec, identifies relevant files, and creates
-                                a task list with parent tasks (first) and sub-tasks (after confirmation).</p>
+                                a task list with parent tasks (first) and sub-tasks (after confirmation) so drift is
+                                caught before implementation starts.</p>
                             <p><strong>Output:</strong> A task list markdown file with demo criteria and proof artifact
                                 requirements</p>
                             <p><strong>Prompt:</strong> <a
@@ -162,8 +167,9 @@
                 </div>
 
                 <blockquote class="quote">
-                    The upfront investment in clarity de-risks the entire development lifecycle by preventing the two
-                    most common causes of project failure: ambiguous requirements and unchecked scope creep.
+                    The highest-leverage work happens in the first two steps: if you nail the spec and task breakdown,
+                    the later steps have a much better chance of succeeding without rework, course correction, or human
+                    intervention.
                 </blockquote>
 
                 <div class="benefits-grid">
@@ -171,6 +177,7 @@
                         <h4>Why This Works</h4>
                         <ul>
                             <li>Built-in scope validation prevents oversized work</li>
+                            <li>Early clarification makes later course correction cheaper and less likely</li>
                             <li>Readable prompts expose patterns teams can study and adapt</li>
                             <li>Tool-agnostic—works with any AI assistant</li>
                             <li>Simple file structure that doesn't pollute your repo</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,10 +27,12 @@
                     <p>Complete a feature in minutes, not days. Liatrio's Spec-Driven Development workflow is
                         <strong>just 4 markdown prompts</strong> that help developers guide an AI assistant through
                         implementing their day-to-day work with structure, clarity, and evidence.</p>
-                    <p>These prompts are <strong>transparent</strong> (you can read and modify every one),
-                        <strong>tool-agnostic</strong> (works with any AI assistant), and <strong>lightweight</strong>
-                        (no installation, no dependencies). They create a simple file structure in
-                        <code>docs/specs/</code> that doesn't pollute your repo.</p>
+                    <p>These prompts are <strong>transparent</strong> and <strong>learnable</strong>: you can read
+                        every prompt, understand the workflow logic it applies, and adapt the patterns to your own team
+                        and projects. Instead of hiding the method inside a product, SDD exposes it in markdown.</p>
+                    <p>They are also <strong>tool-agnostic</strong> (works with any AI assistant) and
+                        <strong>lightweight</strong> (no installation, no dependencies). They create a simple file
+                        structure in <code>docs/specs/</code> that doesn't pollute your repo.</p>
                     <p>View the prompts on GitHub: <a
                             href="https://github.com/liatrio-labs/spec-driven-workflow/tree/main/prompts"
                             target="_blank"
@@ -145,7 +147,9 @@
             <div class="container">
                 <h2>The Four Steps</h2>
                 <p class="section-intro">One person runs through these 4 prompts sequentially with an AI assistant. The
-                    example described on this site took less than 15 minutes from start to finish.</p>
+                    example described on this site took less than 15 minutes from start to finish. Because the prompts
+                    are readable, the workflow also doubles as a guide for learning how to scope work, guide AI, and
+                    verify results more effectively.</p>
 
                 <div class="phases-grid">
                     <div class="phase-card">
@@ -231,7 +235,7 @@
                         <h4>Why This Works</h4>
                         <ul>
                             <li>Built-in scope validation prevents oversized work</li>
-                            <li>Transparent prompts you can read and modify</li>
+                            <li>Readable prompts expose patterns teams can study and adapt</li>
                             <li>Tool-agnostic—works with any AI assistant</li>
                             <li>Simple file structure that doesn't pollute your repo</li>
                             <li>Context verification markers detect instruction loss early</li>
@@ -264,7 +268,7 @@
                     <p><strong>How does this compare to other structured development tools?</strong> See our <a
                             href="comparison.html">comparison against Kiro, SpecKit, and Taskmaster</a> to understand
                         why Liatrio's prompts fit better into the typical workflow of software developers doing
-                        day-to-day work.</p>
+                        day-to-day work, and why exposing the workflow logic matters just as much as lightweight adoption.</p>
                 </div>
             </div>
         </section>
@@ -277,6 +281,9 @@
                     coding into predictable, evidence-based implementation. Liatrio's Spec-Driven Development workflow
                     creates a self-documenting, auditable process that systematically drives up quality, reduces
                     ambiguity, and ensures every feature delivered is a feature validated—all in minutes, not days.</p>
+                <p>The important point is that this process remains visible to the team. Engineers are not only using
+                    AI to move faster; they are learning a repeatable way to frame requirements, direct execution, and
+                    validate output.</p>
 
                 <div class="progression-boxes">
                     <div class="progression-box">
@@ -341,6 +348,9 @@
                 <p>The linkage from Git commit, to task list, to proof artifact forms an unbreakable audit trail from a
                     specific line of code back to the requirement it satisfies. This traceability is non-negotiable and
                     transforms development into a transparent, verifiable process.</p>
+                <p>Because the workflow is documented in prompts and artifacts rather than hidden behind product logic,
+                    the audit trail also becomes a teaching surface teams can inspect to understand how effective
+                    AI-assisted delivery actually works.</p>
 
                 <div class="audit-boxes">
                     <div class="audit-box">

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,13 +26,15 @@
                 <div class="hero-content">
                     <p>Complete a feature in minutes, not days. Liatrio's Spec-Driven Development workflow is
                         <strong>just 4 markdown prompts</strong> that help developers guide an AI assistant through
-                        implementing their day-to-day work with structure, clarity, and evidence.</p>
+                        implementing their day-to-day work with structure, clarity, and evidence.
+                    </p>
                     <p>These prompts are <strong>transparent</strong> and <strong>learnable</strong>: you can read
                         every prompt, understand the workflow logic it applies, and adapt the patterns to your own team
                         and projects. Instead of hiding the method inside a product, SDD exposes it in markdown.</p>
                     <p>They are also <strong>tool-agnostic</strong> (works with any AI assistant) and
                         <strong>lightweight</strong> (no installation, no dependencies). They create a simple file
-                        structure in <code>docs/specs/</code> that doesn't pollute your repo.</p>
+                        structure in <code>docs/specs/</code> that doesn't pollute your repo.
+                    </p>
                     <p>View the prompts on GitHub: <a
                             href="https://github.com/liatrio-labs/spec-driven-workflow/tree/main/prompts"
                             target="_blank"
@@ -70,75 +72,6 @@
                     </div>
                 </div>
 
-                <!-- Step Overview Boxes -->
-                <div class="phase-overview">
-                    <div class="phase-box">
-                        <div class="phase-icon">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
-                                xmlns="http://www.w3.org/2000/svg">
-                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
-                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" />
-                                <path d="M14 2v6h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" />
-                                <path d="M16 13H8" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-                                <path d="M16 17H8" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-                                <path d="M10 9H8" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-                            </svg>
-                        </div>
-                        <h3>Step 1: Specification</h3>
-                        <p>Transform your flow input into a structured spec with clear boundaries</p>
-                        <p class="prompt-link"><a
-                                href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-1-generate-spec.md"
-                                target="_blank" rel="noopener noreferrer">View prompt →</a></p>
-                    </div>
-                    <div class="phase-box">
-                        <div class="phase-icon">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
-                                xmlns="http://www.w3.org/2000/svg">
-                                <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor"
-                                    stroke-width="2" stroke-linecap="round" />
-                            </svg>
-                        </div>
-                        <h3>Step 2: Task Breakdown</h3>
-                        <p>Break the spec into actionable tasks with demo criteria</p>
-                        <p class="prompt-link"><a
-                                href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-2-generate-task-list-from-spec.md"
-                                target="_blank" rel="noopener noreferrer">View prompt →</a></p>
-                    </div>
-                    <div class="phase-box">
-                        <div class="phase-icon">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
-                                xmlns="http://www.w3.org/2000/svg">
-                                <path
-                                    d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
-                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" />
-                            </svg>
-                        </div>
-                        <h3>Step 3: Implementation</h3>
-                        <p>Execute tasks with verification and proof artifacts</p>
-                        <p class="prompt-link"><a
-                                href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-3-manage-tasks.md"
-                                target="_blank" rel="noopener noreferrer">View prompt →</a></p>
-                    </div>
-                    <div class="phase-box">
-                        <div class="phase-icon">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
-                                xmlns="http://www.w3.org/2000/svg">
-                                <path d="M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
-                                    stroke="currentColor" stroke-width="2" />
-                                <path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                                    stroke-linejoin="round" />
-                            </svg>
-                        </div>
-                        <h3>Step 4: Validation</h3>
-                        <p>Verify implementation meets all requirements with evidence</p>
-                        <p class="prompt-link"><a
-                                href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-4-validate-spec-implementation.md"
-                                target="_blank" rel="noopener noreferrer">View prompt →</a></p>
-                    </div>
-                </div>
             </div>
         </section>
 
@@ -163,7 +96,8 @@
                             <p><strong>What It Does:</strong> The prompt validates scope (too large/too small/just
                                 right), asks clarifying questions, and generates a specification document.</p>
                             <p><strong>Output:</strong> A markdown spec file in
-                                <code>docs/specs/[NN]-spec-[feature-name]/</code></p>
+                                <code>docs/specs/[NN]-spec-[feature-name]/</code>
+                            </p>
                             <p><strong>Prompt:</strong> <a
                                     href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-1-generate-spec.md"
                                     target="_blank" rel="noopener noreferrer">SDD-1-generate-spec.md</a></p>
@@ -184,7 +118,8 @@
                                 requirements</p>
                             <p><strong>Prompt:</strong> <a
                                     href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-2-generate-task-list-from-spec.md"
-                                    target="_blank" rel="noopener noreferrer">SDD-2-generate-task-list-from-spec.md</a></p>
+                                    target="_blank" rel="noopener noreferrer">SDD-2-generate-task-list-from-spec.md</a>
+                            </p>
                         </div>
                     </div>
 
@@ -220,7 +155,8 @@
                                 coverage matrix</p>
                             <p><strong>Prompt:</strong> <a
                                     href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-4-validate-spec-implementation.md"
-                                    target="_blank" rel="noopener noreferrer">SDD-4-validate-spec-implementation.md</a></p>
+                                    target="_blank" rel="noopener noreferrer">SDD-4-validate-spec-implementation.md</a>
+                            </p>
                         </div>
                     </div>
                 </div>
@@ -268,7 +204,8 @@
                     <p><strong>How does this compare to other structured development tools?</strong> See our <a
                             href="comparison.html">comparison against Kiro, SpecKit, and Taskmaster</a> to understand
                         why Liatrio's prompts fit better into the typical workflow of software developers doing
-                        day-to-day work, and why exposing the workflow logic matters just as much as lightweight adoption.</p>
+                        day-to-day work, and why exposing the workflow logic matters just as much as lightweight
+                        adoption.</p>
                 </div>
             </div>
         </section>
@@ -379,11 +316,23 @@
         <!-- Directory Structure Section -->
         <section class="directory-structure">
             <div class="container">
-                <h2>Directory Structure</h2>
-                <p>The SDD workflow creates a structured directory layout in <code>docs/specs/</code> that provides a complete audit trail from requirements to implementation:</p>
+                <div class="directory-structure-header">
+                    <h2>Directory Structure</h2>
+                    <p class="section-intro">The SDD workflow creates a structured directory layout in
+                        <code>docs/specs/</code> so every requirement, task, proof, and validation artifact stays
+                        connected in one place.
+                    </p>
+                </div>
 
-                <div class="tree-structure">
-                    <pre><code>docs/specs
+                <div class="directory-structure-layout">
+                    <div class="tree-structure">
+                        <div class="tree-structure-card">
+                            <div class="tree-structure-meta">
+                                <h4>Example Spec Workspace</h4>
+                                <p>A single feature folder contains the full implementation trail from planning through
+                                    proof and validation.</p>
+                            </div>
+                            <pre><code>docs/specs
 ├── 01-spec-feature-name
 │   ├── 01-proofs
 │   │   ├── 01-task-01-proofs.md
@@ -414,38 +363,56 @@
     ├── 03-spec-third-feature.md
     ├── 03-tasks-third-feature.md
     └── 03-validation-third-feature.md</code></pre>
-                </div>
-
-                <div class="structure-explanation">
-                    <div class="structure-column">
-                        <h4>File Naming Convention</h4>
-                        <ul>
-                            <li><strong><code>[NN]-spec-[feature-name]/</code></strong>: Main directory for each feature specification
-                                <ul>
-                                    <li><code>[NN]</code>: Zero-padded 2-digit number (01, 02, 03, etc.)</li>
-                                    <li><code>spec-[feature-name]</code>: Descriptive feature name</li>
-                                </ul>
-                            </li>
-                            <li><strong><code>[NN]-spec-[feature-name].md</code></strong>: The main specification document</li>
-                            <li><strong><code>[NN]-tasks-[feature-name].md</code></strong>: Task breakdown with parent/sub-tasks</li>
-                            <li><strong><code>[NN]-questions-1-[feature-name].md</code></strong>: Clarifying questions and answers</li>
-                            <li><strong><code>[NN]-validation-[feature-name].md</code></strong>: Validation report and coverage matrix</li>
-                            <li><strong><code>[NN]-proofs/</code></strong>: Subdirectory containing proof artifacts
-                                <ul>
-                                    <li><strong><code>[NN]-task-[TT]-proofs.md</code></strong>: Proof artifacts for each parent task</li>
-                                </ul>
-                            </li>
-                        </ul>
+                        </div>
                     </div>
-                    <div class="structure-column">
-                        <h4>Workflow Progression</h4>
-                        <ol>
-                            <li><strong>Specification Phase</strong>: Creates <code>[NN]-spec-[feature-name].md</code> and <code>[NN]-questions-1-[feature-name].md</code></li>
-                            <li><strong>Task Planning Phase</strong>: Creates <code>[NN]-tasks-[feature-name].md</code></li>
-                            <li><strong>Implementation Phase</strong>: Creates <code>[NN]-proofs/[NN]-task-[TT]-proofs.md</code> files as tasks are completed</li>
-                            <li><strong>Validation Phase</strong>: Creates <code>[NN]-validation-[feature-name].md</code> with final validation report</li>
-                        </ol>
-                        <p>This structure provides a complete audit trail from requirements to implementation, with each artifact serving as evidence in the validation process.</p>
+
+                    <div class="structure-explanation">
+                        <div class="structure-column">
+                            <h4>File Naming Convention</h4>
+                            <ul>
+                                <li><strong><code>[NN]-spec-[feature-name]/</code></strong>: Main directory for each
+                                    feature specification
+                                    <ul>
+                                        <li><code>[NN]</code>: Zero-padded 2-digit number (01, 02, 03, etc.)</li>
+                                        <li><code>spec-[feature-name]</code>: Descriptive feature name</li>
+                                    </ul>
+                                </li>
+                                <li><strong><code>[NN]-spec-[feature-name].md</code></strong>: The main specification
+                                    document</li>
+                                <li><strong><code>[NN]-tasks-[feature-name].md</code></strong>: Task breakdown with
+                                    parent/sub-tasks</li>
+                                <li><strong><code>[NN]-questions-1-[feature-name].md</code></strong>: Clarifying
+                                    questions and answers</li>
+                                <li><strong><code>[NN]-validation-[feature-name].md</code></strong>: Validation report
+                                    and coverage matrix</li>
+                                <li><strong><code>[NN]-proofs/</code></strong>: Subdirectory containing proof artifacts
+                                    <ul>
+                                        <li><strong><code>[NN]-task-[TT]-proofs.md</code></strong>: Proof artifacts for
+                                            each parent task</li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="structure-column">
+                            <h4>Workflow Progression</h4>
+                            <ol>
+                                <li><strong>Specification Phase</strong><br> Creates
+                                    <code>[NN]-spec-[feature-name].md</code> and
+                                    <code>[NN]-questions-1-[feature-name].md</code>
+                                </li>
+                                <li><strong>Task Planning Phase</strong><br> Creates
+                                    <code>[NN]-tasks-[feature-name].md</code>
+                                </li>
+                                <li><strong>Implementation Phase</strong><br> Creates
+                                    <code>[NN]-proofs/[NN]-task-[TT]-proofs.md</code> files as tasks are completed
+                                </li>
+                                <li><strong>Validation Phase</strong><br> Creates
+                                    <code>[NN]-validation-[feature-name].md</code> with final validation report
+                                </li>
+                            </ol>
+                            <p>This structure provides a complete audit trail from requirements to implementation, with
+                                each artifact serving as evidence in the validation process.</p>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -180,7 +180,7 @@
                             <li>Early clarification makes later course correction cheaper and less likely</li>
                             <li>Readable prompts expose patterns teams can study and adapt</li>
                             <li>Tool-agnostic—works with any AI assistant</li>
-                            <li>Simple file structure that doesn't pollute your repo</li>
+                            <li>Artifact storage stays lightweight and can adapt to your environment</li>
                             <li>Context verification markers detect instruction loss early</li>
                         </ul>
                     </div>
@@ -217,8 +217,50 @@
             </div>
         </section>
 
+        <section class="phases-detailed">
+            <div class="container">
+                <h2>Where SDD Fits in the Work</h2>
+                <p class="section-intro">SDD is intentionally focused on the implementation loop. In many enterprise
+                    teams, research, prioritization, and architecture decisions already happen upstream in product,
+                    design, or ticketing systems. SDD starts when an engineer has a piece of work ready to execute and
+                    helps carry it through implementation and into review.</p>
+
+                <div class="adaptability-grid">
+                    <div class="shift-item">
+                        <h4>Loop 1: Research and Problem Framing</h4>
+                        <p>This is where requirements are clarified, options are considered, and constraints are
+                            understood. In many teams this already lives in Jira, GitHub issues, design docs, or
+                            product conversations before SDD begins.</p>
+                    </div>
+                    <div class="shift-item">
+                        <h4>Loop 2: Implementation via SDD</h4>
+                        <p>This is the four-step workflow. Specs, tasks, proofs, and validation artifacts help the human
+                            and the AI align on the work, verify progress, and make the reasoning process visible while
+                            the feature is being built.</p>
+                    </div>
+                    <div class="shift-item">
+                        <h4>Loop 3: Review and Iteration</h4>
+                        <p>The PR is reviewed and feedback is incorporated. Implementation feedback can be handled in the
+                            current loop, but directional feedback usually means starting a new spec and a new
+                            implementation run.</p>
+                    </div>
+                </div>
+
+                <div class="scope-validation-section" style="margin-top: 2rem;">
+                    <h3>Artifacts Are Process Scaffolding</h3>
+                    <p>Specs, tasks, proofs, and validation reports are process artifacts, not living documentation.
+                        They exist to guide the implementation loop, help the human verify the AI's understanding, and
+                        make the workflow teachable while the work is in flight.</p>
+                    <p>After that loop completes, the code and tests become the durable source of truth. Some teams keep
+                        these artifacts in <code>docs/specs/</code>, some archive them elsewhere, and some align them to
+                        external systems. SDD intentionally leaves that lifecycle flexible so teams can manage context in
+                        the way that fits their environment.</p>
+                </div>
+            </div>
+        </section>
+
         <!-- From Reactive Art Section -->
-        <section class="reactive-art">
+        <section class="reactive-art progression-section">
             <div class="container">
                 <h2>From Reactive Art to Predictable Engineering</h2>
                 <p>By consistently using these four prompts, developers transform small feature work from reactive
@@ -299,8 +341,8 @@
                 <div class="audit-boxes">
                     <div class="audit-box">
                         <h4>Self-Documenting Process</h4>
-                        <p>Every step generates artifacts that serve as living documentation, creating a complete
-                            project history without additional overhead.</p>
+                        <p>Every step generates a working record of the implementation loop, creating traceability and
+                            shared context without requiring a separate documentation effort.</p>
                     </div>
                     <div class="audit-box">
                         <h4>Auditable Progress</h4>
@@ -325,9 +367,9 @@
             <div class="container">
                 <div class="directory-structure-header">
                     <h2>Directory Structure</h2>
-                    <p class="section-intro">The SDD workflow creates a structured directory layout in
-                        <code>docs/specs/</code> so every requirement, task, proof, and validation artifact stays
-                        connected in one place.
+                    <p class="section-intro">One common way to run SDD is to keep implementation artifacts in
+                        <code>docs/specs/</code> so requirements, tasks, proofs, and validation stay connected in one
+                        place while the work is active.
                     </p>
                 </div>
 
@@ -336,8 +378,8 @@
                         <div class="tree-structure-card">
                             <div class="tree-structure-meta">
                                 <h4>Example Spec Workspace</h4>
-                                <p>A single feature folder contains the full implementation trail from planning through
-                                    proof and validation.</p>
+                                <p>This is one example of an in-repo storage pattern. Teams can keep, archive, or move
+                                    these artifacts differently depending on how they manage planning and context.</p>
                             </div>
                             <pre><code>docs/specs
 ├── 01-spec-feature-name
@@ -417,8 +459,9 @@
                                     <code>[NN]-validation-[feature-name].md</code> with final validation report
                                 </li>
                             </ol>
-                            <p>This structure provides a complete audit trail from requirements to implementation, with
-                                each artifact serving as evidence in the validation process.</p>
+                            <p>This shows one way to store a complete Loop-2 implementation trail in-repo. The exact
+                                retention model is intentionally flexible, and teams can archive or externalize these
+                                artifacts once the implementation loop is complete.</p>
                         </div>
                     </div>
                 </div>

--- a/docs/reference-materials.html
+++ b/docs/reference-materials.html
@@ -85,7 +85,7 @@
                 <h2 class="section-title">Task Proofs & Validation</h2>
                 <p>These artifacts show how SDD turns implementation into something visible. Each proof document is
                     both evidence of completion and an example of how to make AI-driven work verifiable.</p>
-                <div class="reference-grid">
+                <div class="reference-grid reference-grid-balanced">
                     <div class="reference-card">
                         <div class="reference-icon">
                             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -142,7 +142,7 @@
                 <h2 class="section-title">Reports & Analysis</h2>
                 <p>These materials show the final review layer of the workflow: traceability, validation, and the
                     reasoning that connects requirements to delivered code.</p>
-                <div class="reference-grid">
+                <div class="reference-grid reference-grid-balanced">
                     <div class="reference-card">
                         <div class="reference-icon">
                             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -165,6 +165,18 @@
                         <h3>Git Log Analysis</h3>
                         <p>Complete git log and commit history for the cspell feature</p>
                         <a href="references/9___git-log-for-cspell-feature-dark.html" class="reference-link" target="_blank" rel="noopener noreferrer">View Git Log</a>
+                    </div>
+                </div>
+
+                <div class="next-step-cta">
+                    <h3>Ready to Apply SDD in Your Repo?</h3>
+                    <p>Use these artifacts as a study guide, then install the workflow prompts or watch the walkthrough
+                        before trying the process in your own repository.</p>
+                    <div class="next-step-actions">
+                        <a class="next-step-link next-step-link-primary"
+                            href="https://github.com/liatrio-labs/spec-driven-workflow#tldr--quickstart" target="_blank"
+                            rel="noopener noreferrer">Open Quickstart</a>
+                        <a class="next-step-link" href="video-overview.html">Watch the Overview Video</a>
                     </div>
                 </div>
             </div>

--- a/docs/reference-materials.html
+++ b/docs/reference-materials.html
@@ -30,6 +30,9 @@
                     <p>Taken together, they are more than evidence that the workflow worked. They also expose the
                         internal logic of the method so engineers can study how SDD structures intent, guides AI, and
                         verifies outcomes.</p>
+                    <p>This page preserves one complete run for study and demonstration. Teams may keep, archive,
+                        externalize, or discard these artifacts differently depending on how they manage planning,
+                        ticketing, and AI context in their own environment.</p>
                 </div>
                 <hr class="hero-divider">
             </div>

--- a/docs/reference-materials.html
+++ b/docs/reference-materials.html
@@ -20,9 +20,16 @@
         <section class="hero">
             <div class="container">
                 <h1>Reference Materials</h1>
-                <p class="hero-subtitle">Complete documentation and proof artifacts from a real Spec-Driven Development workflow</p>
+                <p class="hero-subtitle">Complete documentation, workflow logic, and proof artifacts from a real
+                    Spec-Driven Development run</p>
                 <div class="hero-content">
-                    <p>These reference materials demonstrate a complete Spec-Driven Development workflow in action. They document the implementation of a cspell pre-commit hook feature, showing the full SDD process from initial conversation through specification, task breakdown, implementation proofs, and validation.</p>
+                    <p>These reference materials demonstrate a complete Spec-Driven Development workflow in action. They
+                        document the implementation of a cspell pre-commit hook feature, showing the full SDD process
+                        from initial conversation through specification, task breakdown, implementation proofs, and
+                        validation.</p>
+                    <p>Taken together, they are more than evidence that the workflow worked. They also expose the
+                        internal logic of the method so engineers can study how SDD structures intent, guides AI, and
+                        verifies outcomes.</p>
                 </div>
                 <hr class="hero-divider">
             </div>
@@ -40,7 +47,8 @@
                             </svg>
                         </div>
                         <h3>AI Conversation</h3>
-                        <p>Complete AI-assisted development conversation and decision making process</p>
+                        <p>Complete AI-assisted development conversation showing how intent, constraints, and decisions
+                            were shaped</p>
                         <a href="references/1___ai-conversation____add-cspell-precommit-hook-dark.html" class="reference-link" target="_blank" rel="noopener noreferrer">View Documentation</a>
                     </div>
 
@@ -52,7 +60,8 @@
                             </svg>
                         </div>
                         <h3>Specification</h3>
-                        <p>Technical specification for the cspell pre-commit hook implementation</p>
+                        <p>Technical specification showing how requirements, boundaries, and success criteria were made
+                            explicit</p>
                         <a href="references/2___05-spec-pre-commit-cspell-dark.html" class="reference-link" target="_blank" rel="noopener noreferrer">View Specification</a>
                     </div>
 
@@ -63,7 +72,8 @@
                             </svg>
                         </div>
                         <h3>Tasks Overview</h3>
-                        <p>Detailed task breakdown and implementation roadmap</p>
+                        <p>Detailed task breakdown showing how the spec was converted into an executable implementation
+                            plan</p>
                         <a href="references/3___05-tasks-pre-commit-cspell-dark.html" class="reference-link" target="_blank" rel="noopener noreferrer">View Tasks</a>
                     </div>
                 </div>
@@ -73,6 +83,8 @@
         <section class="reference-grid-section">
             <div class="container">
                 <h2 class="section-title">Task Proofs & Validation</h2>
+                <p>These artifacts show how SDD turns implementation into something visible. Each proof document is
+                    both evidence of completion and an example of how to make AI-driven work verifiable.</p>
                 <div class="reference-grid">
                     <div class="reference-card">
                         <div class="reference-icon">
@@ -128,6 +140,8 @@
         <section class="reference-grid-section">
             <div class="container">
                 <h2 class="section-title">Reports & Analysis</h2>
+                <p>These materials show the final review layer of the workflow: traceability, validation, and the
+                    reasoning that connects requirements to delivered code.</p>
                 <div class="reference-grid">
                     <div class="reference-card">
                         <div class="reference-icon">

--- a/docs/video-overview.html
+++ b/docs/video-overview.html
@@ -22,7 +22,11 @@
             <div class="container">
                 <h1>Spec Driven Development Workflow</h1>
                 <div class="hero-content">
-                    <p>Discover how Spec Driven Development transforms software creation. This workflow connects planning, design, and execution seamlessly. Watch our brief video overview (courtesy of NotebookLM) to master this powerful approach.</p>
+                    <p>Discover how Spec Driven Development transforms software creation. This workflow connects
+                        planning, design, and execution seamlessly.</p>
+                    <p>Watch this brief video overview (courtesy of NotebookLM) to understand not only the four-step
+                        workflow, but also the reasoning patterns SDD makes visible for teams learning how to work with
+                        AI effectively.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Why?

Improves the public-facing documentation site in two connected ways: a balanced, factual rewrite of the competitor comparison page, and a broader refresh of the docs experience so the workflow story is easier to follow from page to page. The updates also sharpen the message that SDD is a teachable, inspectable workflow - not just a productivity tool.

## What Changed?

### Comparison Page Overhaul (`docs/comparison.html`)

- **Reframed the narrative**: Changed the hero heading from \"Why Not Other Structured Development Tools?\" to \"Comparing SDD to Other Structured Development Tools\" - shifting from dismissive framing to factual comparison.
- **Expanded the comparison table from 2 columns to 4**: Each competitor (Kiro, SpecKit, Taskmaster) now has its own column with specific, sourced assessments instead of being grouped into a single \"others\" bucket.
- **Added hyperlinks to competitor docs**: Setup, installation, and workflow claims now link directly to official competitor documentation so readers can verify claims themselves.
- **Replaced blanket red/green ratings with nuanced assessments**: Uses a mix of green/yellow/red indicators with explanatory text instead of binary pass/fail judgments.
- **Added transparency as a comparison dimension**: New row highlights SDD's distinguishing trait - workflow logic is in readable markdown, not hidden behind product behavior.
- **Rewrote the setup and conclusion sections**: Renamed \"Getting Started\" to \"Repo-Native Setup\" and reframed \"The Bottom Line\" around adoption cost, operating model fit, and teachability.
- **Added a next-step CTA**: The page now routes readers into the developer-experience and FAQ content instead of ending with a simple back-link.

### Docs Messaging and Layout Refresh (`docs/index.html`, `docs/developer-experience.html`, `docs/common-questions.html`, `docs/reference-materials.html`, `docs/video-overview.html`)

- **"Teachable workflow" theme**: Added language across the site emphasizing that SDD exposes its method in readable prompts and artifacts, so engineers learn effective AI collaboration patterns rather than depending on a product to manage them.
- **Homepage refresh (`docs/index.html`)**: Updated hero copy, strengthened the four-step explanation, clarified the cspell example references, emphasized that Steps 1 and 2 are the highest-leverage part of the workflow, added a new spec lifecycle section explaining where SDD fits in the broader delivery process, improved audit-trail framing, redesigned the directory-structure section, and added a next-step CTA that moves readers deeper into the site.
- **Developer experience page**: Added visibility/teachability language, linked the cspell case study more clearly, introduced new supporting callouts such as \"Teachable AI Collaboration\" and \"Visible Working Method,\" and added a next-step CTA.
- **Common questions page**: Expanded messaging around visible workflow logic, clarified the cspell example links, strengthened the shift-left argument for upfront planning, added a new FAQ on spec/task/proof lifecycle and PR feedback types, refined the technical background/non-goals presentation, and added a next-step CTA toward the walkthrough and reference materials.
- **Reference materials page**: Reframed artifacts as both evidence and teaching material, clarified that the preserved cspell run is illustrative rather than a required retention model, balanced the card grids, and added a next-step CTA toward quickstart and the walkthrough.
- **Video overview page**: Expanded the hero copy so the video is framed as both an overview of the flow and an explanation of the reasoning patterns SDD makes visible.

### Shared Docs UI Refinements (`docs/assets/css/styles.css`)

- Added reusable **next-step CTA** styles used across multiple pages.
- Refined the **comparison table** styling, including header treatment, row striping, spacing, and link presentation.
- Added page-specific layout improvements for the **homepage directory structure**, **developer-experience cards/sections**, **common-questions non-goals and technical background blocks**, and **reference-materials grid balance**.
- Added a distinct background treatment for the homepage's **From Reactive Art to Predictable Engineering** section so it stays visually separated after the new lifecycle section was introduced.
- Added several hover, spacing, and responsive layout improvements to make the docs pages feel more intentional and easier to scan.

## Notes

- Ordering: Independent, no merge dependency on other split PRs
- Process: Split from `feat/add-pre-commit-for-cspell` using two-phase branch surgery; 5 WIP commits squashed into clean history
- Companion PR: #48 (cspell CI tooling setup)