### PR TITLE
feat(prompts): harden SDD planning, clarification, and review workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 This repository provides **structured prompts** (Markdown files) that guide AI assistants through a complete software development workflow:
 
 - **Define intent**: generate a reviewed spec with clear demo criteria
-- **Plan**: break work into demoable tasks and subtasks
+- **Plan**: break work into demoable tasks and subtasks, then run a planning audit gate
 - **Execute**: implement with checkpoints and proof artifacts
 - **Validate**: verify implementation against the spec with evidence
 
@@ -93,8 +93,8 @@ Copy the contents of a prompt file directly from `prompts/` and paste it into yo
 ### Quick "try it" flow
 
 1. Run `/SDD-1-generate-spec` and describe the feature you want.
-2. Next, use `/SDD-2-generate-task-list-from-spec` pointing it at the generated spec.
-3. Then execute `/SDD-3-manage-tasks` to implement tasks one at a time (creating proof artifacts before commits).
+2. Next, use `/SDD-2-generate-task-list-from-spec` pointing it at the generated spec; complete task generation, baseline planning commit, planning audit, and user-approved remediation if needed.
+3. Then execute `/SDD-3-manage-tasks` to implement tasks one at a time (creating proof artifacts before commits) after the SDD-2 audit required gates pass.
 4. Finally, apply `/SDD-4-validate-spec-implementation` to verify the implementation against the spec.
 
 ## Details for the 4-step workflow
@@ -107,9 +107,9 @@ Each step uses a different prompt file and produces specific artifacts in `docs/
    - **Why**: aligns humans + AI on what to build before any code changes
 
 2. **Generate a task list** ([`prompts/SDD-2-generate-task-list-from-spec.md`](./prompts/SDD-2-generate-task-list-from-spec.md))
-   - **What it does**: converts the spec into parent tasks (demoable units) + detailed subtasks with a "Relevant Files" section
-   - **Output**: `docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
-   - **Why**: creates an actionable plan with clear checkpoints and reviewable scope
+   - **What it does**: converts the spec into parent tasks (demoable units) + detailed subtasks, creates a baseline planning commit, runs a planning audit gate, and requires user-approved remediation before implementation handoff
+   - **Output**: `docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` and `docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`
+   - **Why**: catches planning defects early and improves downstream validation readiness
 
 3. **Manage tasks (implementation loop)** ([`prompts/SDD-3-manage-tasks.md`](./prompts/SDD-3-manage-tasks.md))
    - **What it does**: guides execution with checkpoints, verification checklists, and proof artifacts created **before** each commit
@@ -126,6 +126,7 @@ Each step uses a different prompt file and produces specific artifacts in `docs/
 ## Highlights
 
 - **Prompt-first workflow:** Use curated prompts to go from idea → spec → task list → implementation-ready backlog.
+- **Planning quality gate:** SDD-2 includes a mandatory audit with human-approved remediation before implementation starts.
 - **Predictable delivery:** Every step emphasizes demoable slices, proof artifacts, and collaboration with junior developers in mind.
 - **No dependencies required:** The prompts are plain Markdown files that work with any AI assistant.
 - **Context verification:** Built-in emoji markers (SDD1️⃣-SDD4️⃣) detect when AI responses follow critical instructions, helping identify context rot issues early.
@@ -148,6 +149,7 @@ Each prompt writes Markdown outputs into `docs/specs/[NN]-spec-[feature-name]/` 
 
 - **Specs:** `docs/specs/[NN]-spec-[feature-name]/[NN]-spec-[feature-name].md`
 - **Task lists:** `docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
+- **Audit reports:** `docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`
 - **Proof artifacts:** `docs/specs/[NN]-spec-[feature-name]/[NN]-proofs/[NN]-task-[TT]-proofs.md`
 - **Validation reports:** `docs/specs/[NN]-spec-[feature-name]/[NN]-validation-[feature-name].md`
 
@@ -162,6 +164,7 @@ docs/specs
     │   ├── 01-task-03-proofs.md
     │   └── 01-task-04-proofs.md
     ├── 01-questions-1-feature-name.md
+    ├── 01-audit-feature-name.md
     ├── 01-spec-feature-name.md
     ├── 01-tasks-feature-name.md
     └── 01-validation-feature-name.md

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Copy the contents of a prompt file directly from `prompts/` and paste it into yo
 Each step uses a different prompt file and produces specific artifacts in `docs/specs/`.
 
 1. **Generate a spec** ([`prompts/SDD-1-generate-spec.md`](./prompts/SDD-1-generate-spec.md))
-   - **What it does**: checks scope, determines whether clarification is needed, optionally creates a questions file for material ambiguities with recommended answers and justification notes, and writes a junior-friendly spec with demo criteria
+   - **What it does**: checks scope, researches current best practices for relevant technologies, determines whether clarification is needed, optionally creates a questions file for material ambiguities with recommended answers and justification notes, and writes a junior-friendly spec with demo criteria
    - **Output**: `docs/specs/[NN]-spec-[feature-name]/[NN]-spec-[feature-name].md` and, when needed, `docs/specs/[NN]-spec-[feature-name]/[NN]-questions-[N]-[feature-name].md`
    - **Why**: aligns humans + AI on what to build before any code changes
 
@@ -138,6 +138,7 @@ Spec-Driven Development (SDD) keeps AI collaborators and human developers aligne
 ## Guiding Principles
 
 - **Clarify intent before delivery:** The spec prompt requires a clarification sufficiency check so material ambiguities are resolved before planning, while minor uncertainty can remain explicit in the spec.
+- **Ground plans in current guidance:** The spec prompt combines repository pattern discovery with current external best-practice research for material technologies, then asks follow-up questions when those signals still leave meaningful choices open.
 - **Ship demoable slices:** Every stage pushes toward thin, end-to-end increments with clear demo criteria and proof artifacts.
 - **Make work transparent:** Tasks live in versioned markdown files so stakeholders can review, comment, and adjust scope anytime.
 - **Progress one slice at a time:** The management prompt enforces single-threaded execution to reduce churn and unfinished work-in-progress.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Copy the contents of a prompt file directly from `prompts/` and paste it into yo
 
 ### Quick "try it" flow
 
-1. Run `/SDD-1-generate-spec` and describe the feature you want.
+1. Run `/SDD-1-generate-spec` and describe the feature you want. If the AI determines material clarification is needed, answer the generated questions file before continuing.
 2. Next, use `/SDD-2-generate-task-list-from-spec` pointing it at the generated spec; complete task generation, baseline planning commit, planning audit, and user-approved remediation if needed.
 3. Then execute `/SDD-3-manage-tasks` to implement tasks one at a time (creating proof artifacts before commits) after the SDD-2 audit required gates pass.
 4. Finally, apply `/SDD-4-validate-spec-implementation` to verify the implementation against the spec.
@@ -102,8 +102,8 @@ Copy the contents of a prompt file directly from `prompts/` and paste it into yo
 Each step uses a different prompt file and produces specific artifacts in `docs/specs/`.
 
 1. **Generate a spec** ([`prompts/SDD-1-generate-spec.md`](./prompts/SDD-1-generate-spec.md))
-   - **What it does**: asks structured clarifying questions, checks scope, and writes a junior-friendly spec with demo criteria
-   - **Output**: `docs/specs/[NN]-spec-[feature-name]/[NN]-spec-[feature-name].md`
+   - **What it does**: checks scope, determines whether clarification is needed, optionally creates a questions file for material ambiguities with recommended answers and justification notes, and writes a junior-friendly spec with demo criteria
+   - **Output**: `docs/specs/[NN]-spec-[feature-name]/[NN]-spec-[feature-name].md` and, when needed, `docs/specs/[NN]-spec-[feature-name]/[NN]-questions-[N]-[feature-name].md`
    - **Why**: aligns humans + AI on what to build before any code changes
 
 2. **Generate a task list** ([`prompts/SDD-2-generate-task-list-from-spec.md`](./prompts/SDD-2-generate-task-list-from-spec.md))
@@ -137,7 +137,7 @@ Spec-Driven Development (SDD) keeps AI collaborators and human developers aligne
 
 ## Guiding Principles
 
-- **Clarify intent before delivery:** The spec prompt enforces clarifying questions so requirements are explicit and junior-friendly.
+- **Clarify intent before delivery:** The spec prompt requires a clarification sufficiency check so material ambiguities are resolved before planning, while minor uncertainty can remain explicit in the spec.
 - **Ship demoable slices:** Every stage pushes toward thin, end-to-end increments with clear demo criteria and proof artifacts.
 - **Make work transparent:** Tasks live in versioned markdown files so stakeholders can review, comment, and adjust scope anytime.
 - **Progress one slice at a time:** The management prompt enforces single-threaded execution to reduce churn and unfinished work-in-progress.
@@ -148,12 +148,15 @@ Spec-Driven Development (SDD) keeps AI collaborators and human developers aligne
 Each prompt writes Markdown outputs into `docs/specs/[NN]-spec-[feature-name]/` (where `[NN]` is a zero-padded 2-digit number: 01, 02, 03, etc.), giving you a lightweight backlog that is easy to review, share, and implement.
 
 - **Specs:** `docs/specs/[NN]-spec-[feature-name]/[NN]-spec-[feature-name].md`
+- **Questions files (when needed):** `docs/specs/[NN]-spec-[feature-name]/[NN]-questions-[N]-[feature-name].md`
 - **Task lists:** `docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
 - **Audit reports:** `docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`
 - **Proof artifacts:** `docs/specs/[NN]-spec-[feature-name]/[NN]-proofs/[NN]-task-[TT]-proofs.md`
 - **Validation reports:** `docs/specs/[NN]-spec-[feature-name]/[NN]-validation-[feature-name].md`
 
 Example directory structure:
+
+`[NN]-questions-[N]-[feature-name].md` is optional and appears only when the spec prompt determines a clarification round is required.
 
 ```bash
 docs/specs

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,6 +38,14 @@ Commands and scaffolds steer teams toward skateboard‑to‑scooter increments: 
 
 Yes. You can keep everything in a single repository using Markdown files with no external dependencies. Tool integrations and multi‑repo features are optional.
 
+## How does the workflow prevent low-quality planning from reaching implementation?
+
+The planning step includes a mandatory audit gate after task generation. The AI produces an audit report that checks requirement coverage, proof artifact quality, repository standards consistency, open-question handling, and context alignment against related docs (such as specs, PRDs, or roadmaps). Required failures block implementation handoff until remediated.
+
+## Is remediation fully automated?
+
+No. Remediation is human-in-the-loop. The AI presents findings and a concrete remediation plan, then waits for explicit user approval before editing planning artifacts. After approved edits, the AI reruns the audit. This loop repeats until required audit gates pass.
+
 ## Can solo developers use it?
 
 Yes. The same context and work‑breakdown helpers make it easy to pause and resume personal projects while keeping AI assistance on track.

--- a/prompts/SDD-1-generate-spec.md
+++ b/prompts/SDD-1-generate-spec.md
@@ -325,6 +325,23 @@ If no specific security considerations, state "No specific security consideratio
 
 ## Step 6: Review and Refinement
 
+### Cross-Domain Applicability Guard (Required)
+
+Before presenting the spec to the user, run this check to keep the workflow
+broadly applicable across software tasks (API, UI, CLI, data, infra,
+platform):
+
+- [ ] The spec language is domain-neutral (no project-specific assumptions
+      unless user-provided).
+- [ ] Demoable Units can be validated in at least one of these contexts: API,
+      UI, CLI, data pipeline, or infrastructure automation.
+- [ ] Proof Artifacts are defined as observable outcomes, not tool-specific
+      rituals.
+- [ ] Requirements are written so another repository could reuse the structure
+      with only context substitutions.
+
+If any item fails, revise wording to be framework-agnostic and context-aware.
+
 After generating the spec, present it to the user and ask:
 
 1. "Does this specification accurately capture your requirements?"

--- a/prompts/SDD-1-generate-spec.md
+++ b/prompts/SDD-1-generate-spec.md
@@ -98,6 +98,28 @@ If working in a pre-existing project, begin by briefly reviewing the codebase an
 
 **Use this context to inform scope validation and requirements, not to drive technical decisions.** Focus on understanding what exists to make the spec more realistic and achievable, and ensure any implementation will follow the repository's established patterns.
 
+### Latest Technology Standards Research (Required When Relevant)
+
+Before finalizing clarification status or generating the spec, identify the technologies, frameworks, platforms, libraries, or service categories that are explicitly mentioned or strongly implied by the request.
+
+For each technology that materially affects the spec:
+
+- Use web research to look up current best practices and standards beyond the model's training data.
+- Prioritize official documentation, vendor guidance, standards bodies, or other high-signal primary sources.
+- Prefer current-year guidance when available, then the previous year, before using older material.
+- Capture only the practices that materially affect feature design, validation, security, maintainability, or user experience.
+- Note any tension between repository patterns and current external guidance.
+
+Record a short internal research summary covering:
+
+- Technology researched
+- Source(s) consulted
+- Recency signal (publication/update date when available, otherwise note that the source is a living document)
+- 1-3 relevant best practices or standards
+- Any unresolved ambiguity that should be confirmed with the user
+
+If no technology-specific external guidance is relevant, explicitly state that no latest-standards research was needed.
+
 ## Step 3: Initial Scope Assessment
 
 Evaluate whether this feature request is appropriately sized for this spec-driven workflow.
@@ -184,6 +206,7 @@ Proceed without a questions file only if all of the following are true:
 - Scope boundaries are clear enough to define meaningful non-goals.
 - Demoable Units and Proof Artifacts can be specified without guessing.
 - Known repository context and user-provided constraints are sufficient to avoid inventing requirements.
+- Relevant latest-standards research has been completed for material technologies, and it does not introduce unresolved approach choices that need user confirmation.
 - Any remaining uncertainty is minor and can safely be recorded in the spec's `Open Questions` section without reducing spec quality.
 
 Create a questions file if any of the following are true:
@@ -193,6 +216,8 @@ Create a questions file if any of the following are true:
 - Scope boundaries or non-goals are unclear.
 - Design, technical, integration, security, or operational constraints are missing and would materially change the spec.
 - The user intent or direction could reasonably lead to different implementation paths.
+- Current best practices or standards for a relevant technology suggest multiple valid approaches, and the choice would materially affect the spec.
+- Repository patterns appear to conflict with current external guidance, and the correct direction is not obvious from the user's request.
 
 ### Clarification Status Declaration (Required)
 
@@ -207,6 +232,7 @@ Before choosing `sufficient`, explicitly verify:
 
 - [ ] I am not guessing at missing requirements.
 - [ ] I can populate all major spec sections with grounded, user-aligned content.
+- [ ] I have reviewed relevant current best practices for material technologies, or I have explicitly determined that no external standards research is needed.
 - [ ] Any remaining uncertainty is non-blocking and belongs in `Open Questions` rather than a blocking questions round.
 
 If any check fails, create a questions file.
@@ -216,6 +242,8 @@ If any check fails, create a questions file.
 Follow this format exactly when you create a questions file.
 
 Each question MUST include recommended answer guidance for the user. Recommendations should reduce ambiguity, explain tradeoffs, and bias toward the option that best supports a clear, reviewable, junior-friendly spec.
+
+If a question is driven by latest-standards research, include a short note summarizing the relevant current guidance and why user confirmation is needed.
 
 ```markdown
 # [NN] Questions Round 1 - [Feature Name]
@@ -231,6 +259,8 @@ Please answer each question below (select one or more options, or add your own n
 - [ ] (C) [Option description explaining what this choice means]
 - [ ] (D) [Option description explaining what this choice means]
 - [ ] (E) Other (describe)
+
+**Current best-practice context:** [Optional. Briefly summarize the latest relevant guidance or standard that makes this question important. Omit if not needed.]
 
 **Recommended answer(s):** [(A), (C)]
 
@@ -248,6 +278,8 @@ Please answer each question below (select one or more options, or add your own n
 - [ ] (C) [Option description explaining what this choice means]
 - [ ] (D) [Option description explaining what this choice means]
 - [ ] (E) Other (describe)
+
+**Current best-practice context:** [Optional. Briefly summarize the latest relevant guidance or standard that makes this question important. Omit if not needed.]
 
 **Recommended answer(s):** [(B)]
 
@@ -267,6 +299,8 @@ When adding recommended answer guidance:
 - Do not present recommendations as mandatory; the user remains the decision-maker.
 - If no option is clearly safer or more aligned, say so explicitly and explain the tradeoff instead of forcing a weak recommendation.
 - If recommending `Other`, provide a short suggested custom answer the user can edit.
+- When the question comes from latest-standards research, summarize the relevant current guidance in plain language before recommending an answer.
+- Use user confirmation to resolve meaningful tension between repository patterns and current external best practices.
 
 ### Example Question With Recommendation Guidance
 
@@ -284,6 +318,8 @@ Which sign-in methods should this first version support?
 - [ ] (E) Other (describe)
 
 **Recommended answer(s):** [(A)]
+
+**Current best-practice context:** Current guidance for new authentication work often recommends shipping the smallest secure end-to-end slice first, then layering optional auth methods once the base flow is validated.
 
 **Why these are recommended:**
 
@@ -390,7 +426,7 @@ Generate a comprehensive specification using this exact structure:
 
 ## Technical Considerations
 
-[Focus on implementation constraints and HOW it will be built. Mention technical constraints, dependencies, or architectural decisions. If no technical constraints, state "No specific technical constraints identified."]
+[Focus on implementation constraints and HOW it will be built. Mention technical constraints, dependencies, or architectural decisions. Incorporate relevant current best practices or standards discovered during latest-standards research, and call out any explicit deviation that should remain because of repository or user context. If no technical constraints, state "No specific technical constraints identified."]
 
 ## Security Considerations
 
@@ -461,16 +497,19 @@ Iterate based on feedback until the user is satisfied.
 - Use jargon or technical terms that a junior developer wouldn't understand
 - Skip the clarification sufficiency check, even if the prompt seems clear
 - Ignore existing repository patterns and conventions
+- Rely only on stale model knowledge when current external guidance could materially affect the spec
 
 **ALWAYS:**
 
 - Run the clarification sufficiency check before generating the spec
 - Ask clarifying questions when material ambiguity remains
+- Research current best practices for material technologies when they could affect the spec
 - Validate scope appropriateness before proceeding
 - Use the exact spec structure provided above
 - Ensure the spec is understandable by a junior developer
 - Include proof artifacts for each work unit that demonstrate what will be shown
 - Follow identified repository standards and patterns in all requirements
+- Incorporate relevant current external standards and best practices in technical guidance
 
 ## What Comes Next
 

--- a/prompts/SDD-1-generate-spec.md
+++ b/prompts/SDD-1-generate-spec.md
@@ -64,13 +64,13 @@ If the user did not include an initial input or reference for the spec, ask the 
 1. **Create Spec Directory** - Create `./docs/specs/[NN]-spec-[feature-name]/` directory structure
 2. **Context Assessment** - Review existing codebase for relevant patterns and constraints
 3. **Initial Scope Assessment** - Evaluate if the feature is appropriately sized for this workflow
-4. **Clarifying Questions** - Gather detailed requirements through structured inquiry
+4. **Clarification Decision** - Decide whether the current context is sufficient or whether a questions file is required
 5. **Spec Generation** - Create the detailed specification document
 6. **Review and Refine** - Validate completeness and clarity with the user
 
 ## Step 1: Create Spec Directory
 
-Create the spec directory structure before proceeding with any other steps. This ensures all files (questions, spec, tasks, proofs) have a consistent location.
+Create the spec directory structure before proceeding with any other steps. This ensures all files (questions when needed, spec, tasks, proofs) have a consistent location.
 
 **Directory Structure:**
 
@@ -145,11 +145,13 @@ Evaluate whether this feature request is appropriately sized for this spec-drive
 - **ALWAYS** inform the user of the result of the scope assessment.
 - If the scope appears inappropriate, **ALWAYS** pause the conversation to suggest alternatives and get input from the user.
 
-## Step 4: Clarifying Questions
+## Step 4: Clarification Sufficiency Check
 
-Ask clarifying questions to gather sufficient detail. Focus on understanding the "what" and "why" rather than the "how."
+Assess whether you already have enough aligned context to write a high-quality spec without inventing requirements. Always err on the side of caution, but do not force a questions file when the available information is already sufficient.
 
-Use the following common areas to guide your questions:
+Focus on understanding the "what" and "why" rather than the "how."
+
+Use the following common areas to assess whether clarification is needed:
 
 **Core Understanding:**
 
@@ -174,9 +176,46 @@ Use the following common areas to guide your questions:
 
 **Progressive Disclosure:** Start with Core Understanding, then expand based on feature complexity and user responses.
 
+### Clarification Sufficiency Criteria
+
+Proceed without a questions file only if all of the following are true:
+
+- The user goal and intended outcome are clear.
+- Scope boundaries are clear enough to define meaningful non-goals.
+- Demoable Units and Proof Artifacts can be specified without guessing.
+- Known repository context and user-provided constraints are sufficient to avoid inventing requirements.
+- Any remaining uncertainty is minor and can safely be recorded in the spec's `Open Questions` section without reducing spec quality.
+
+Create a questions file if any of the following are true:
+
+- There are multiple materially different interpretations of the requested feature.
+- Acceptance criteria, Proof Artifacts, or Demoable Units would otherwise be guessed.
+- Scope boundaries or non-goals are unclear.
+- Design, technical, integration, security, or operational constraints are missing and would materially change the spec.
+- The user intent or direction could reasonably lead to different implementation paths.
+
+### Clarification Status Declaration (Required)
+
+Before proceeding, you MUST state exactly one of the following:
+
+- `Clarification status: sufficient - no questions file required`
+- `Clarification status: insufficient - questions file required`
+
+### Self-Verification Before Proceeding
+
+Before choosing `sufficient`, explicitly verify:
+
+- [ ] I am not guessing at missing requirements.
+- [ ] I can populate all major spec sections with grounded, user-aligned content.
+- [ ] Any remaining uncertainty is non-blocking and belongs in `Open Questions` rather than a blocking questions round.
+
+If any check fails, create a questions file.
+
 ### Questions File Format
 
-Follow this format exactly when you create the questions file.
+Follow this format exactly when you create a questions file.
+
+Each question MUST include recommended answer guidance for the user. Recommendations should reduce ambiguity, explain tradeoffs, and bias toward the option that best supports a clear, reviewable, junior-friendly spec.
 
 ```markdown
 # [NN] Questions Round 1 - [Feature Name]
@@ -193,6 +232,13 @@ Please answer each question below (select one or more options, or add your own n
 - [ ] (D) [Option description explaining what this choice means]
 - [ ] (E) Other (describe)
 
+**Recommended answer(s):** [(A), (C)]
+
+**Why these are recommended:**
+
+- [Recommendation note 1 explaining why the suggested option best preserves user intent, reduces ambiguity, or improves spec quality]
+- [Recommendation note 2 explaining tradeoffs versus the other options]
+
 ## 2. [Another Question Category/Topic]
 
 [What specific aspect of the feature needs clarification?]
@@ -202,23 +248,71 @@ Please answer each question below (select one or more options, or add your own n
 - [ ] (C) [Option description explaining what this choice means]
 - [ ] (D) [Option description explaining what this choice means]
 - [ ] (E) Other (describe)
+
+**Recommended answer(s):** [(B)]
+
+**Why these are recommended:**
+
+- [Recommendation note 1 explaining why the suggested option best preserves user intent, reduces ambiguity, or improves spec quality]
+- [Recommendation note 2 explaining tradeoffs versus the other options]
+```
+
+### Recommendation Rules For Questions Files
+
+When adding recommended answer guidance:
+
+- Recommend the option or combination of options that best supports alignment with the user's likely intent.
+- Explain why the recommendation is better than the alternatives presented, not just why it is reasonable in isolation.
+- Prefer recommendations that reduce avoidable ambiguity and make the eventual spec easier to validate.
+- Do not present recommendations as mandatory; the user remains the decision-maker.
+- If no option is clearly safer or more aligned, say so explicitly and explain the tradeoff instead of forcing a weak recommendation.
+- If recommending `Other`, provide a short suggested custom answer the user can edit.
+
+### Example Question With Recommendation Guidance
+
+Use this as a style reference for how to recommend answers without taking the decision away from the user.
+
+```markdown
+## 1. Authentication Entry Point
+
+Which sign-in methods should this first version support?
+
+- [ ] (A) Email and password only
+- [ ] (B) Google SSO only
+- [ ] (C) Email/password and Google SSO together
+- [ ] (D) Magic link only
+- [ ] (E) Other (describe)
+
+**Recommended answer(s):** [(A)]
+
+**Why these are recommended:**
+
+- `(A)` is the smallest demoable slice and keeps the first spec focused on one complete authentication path.
+- `(A)` reduces ambiguity in validation, proof artifacts, and edge cases compared with `(C)`, which adds a second auth flow immediately.
+- `(B)` and `(D)` may still be valid product choices, but they introduce external-provider or email-delivery dependencies that are usually unnecessary unless the user explicitly wants them.
+- If the user already knows SSO is a hard requirement, they should override this recommendation.
 ```
 
 ### Questions File Process
 
+Only follow this process when clarification is insufficient.
+
 1. **Create Questions File**: Save questions to a file named `[NN]-questions-[N]-[feature-name].md` where `[N]` is the round number (starting at 1, incrementing for each new round).
-2. **Point User to File**: Direct the user to the questions file and instruct them to answer the questions directly in the file.
-3. **STOP AND WAIT**: Do not proceed to Step 5. Wait for the user to indicate they have saved their answers.
-4. **Read Answers**: After the user indicates they have saved their answers, read the file and continue the conversation.
-5. **Follow-Up Rounds**: If answers reveal new questions, create a new questions file with incremented round number (`[NN]-questions-[N+1]-[feature-name].md`) and repeat the process (return to step 3).
+2. **Augment With Recommendations**: For every question, include recommended answer(s) and short justification notes comparing the recommendation to the other options.
+3. **Point User to File**: Direct the user to the questions file and instruct them to answer the questions directly in the file.
+4. **STOP AND WAIT**: Do not proceed to Step 5. Wait for the user to indicate they have saved their answers.
+5. **Read Answers**: After the user indicates they have saved their answers, read the file and continue the conversation.
+6. **Re-run Sufficiency Check**: Reassess whether the combined context is now sufficient to generate the spec.
+7. **Follow-Up Rounds**: If answers reveal new material ambiguity, create a new questions file with incremented round number (`[NN]-questions-[N+1]-[feature-name].md`) and repeat the process (return to step 3).
 
 **Iterative Process:**
 
-- If a user's answer reveals new questions or areas needing clarification, ask follow-up questions in a new questions file.
+- If a user's answer reveals new material questions or areas needing clarification, ask follow-up questions in a new questions file.
 - Build on previous answers - use context from earlier responses to inform subsequent questions.
 - **CRITICAL**: After creating any questions file, you MUST STOP and wait for the user to provide answers before proceeding.
 - Only proceed to Step 5 after:
   - You have received and reviewed all user answers to clarifying questions
+  - You have re-run the Clarification Sufficiency Check
   - You have enough detail to populate all spec sections (User Stories, Demoable Units with functional requirements, etc.).
 
 ## Step 5: Spec Generation
@@ -365,12 +459,13 @@ Iterate based on feedback until the user is satisfied.
 - Assume technical details without asking the user
 - Create specs that are too large or too small without addressing scope issues
 - Use jargon or technical terms that a junior developer wouldn't understand
-- Skip the clarifying questions phase, even if the prompt seems clear
+- Skip the clarification sufficiency check, even if the prompt seems clear
 - Ignore existing repository patterns and conventions
 
 **ALWAYS:**
 
-- Ask clarifying questions before generating the spec
+- Run the clarification sufficiency check before generating the spec
+- Ask clarifying questions when material ambiguity remains
 - Validate scope appropriateness before proceeding
 - Use the exact spec structure provided above
 - Ensure the spec is understandable by a junior developer

--- a/prompts/SDD-1-generate-spec.md
+++ b/prompts/SDD-1-generate-spec.md
@@ -362,4 +362,12 @@ Iterate based on feedback until the user is satisfied.
 
 ## What Comes Next
 
-Once this spec is complete and approved, instruct the user to run `/SDD-2-generate-task-list-from-spec`. This will start the next step in the workflow, which is to break down the specification into actionable tasks.
+Once this spec is complete and approved, instruct the user to run `/SDD-2-generate-task-list-from-spec`. In that step, the AI will:
+
+1. Generate parent tasks and sub-tasks
+2. Create a baseline planning commit (spec + tasks + questions files when present)
+3. Run a planning audit and create `[NN]-audit-[feature-name].md`
+4. Present findings and a remediation plan for explicit user approval before any remediation edits
+5. Re-run the audit until all required gates pass
+
+Only after those audit gates pass should the workflow proceed to `/SDD-3-manage-tasks`.

--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -191,9 +191,9 @@ Do not proceed to Phase 2 until you produce a standards evidence table with:
 
 Wait for explicit user confirmation before generating sub-tasks. Then:
 
-1. **Identify Relevant Files:** List all files that will need creation or modification
+1. **Identify Relevant Files:** Capture all files that will need creation or modification in a markdown table
 2. **Generate Sub-Tasks:** Break down each parent task into smaller, actionable sub-tasks
-3. **Update Task List:** Update the existing `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` file with the sub-tasks and relevant files sections
+3. **Update Task List:** Update the existing `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` file with the sub-tasks and relevant files table sections
 
 ### Phase 4: Planning Audit Gate (Required)
 
@@ -291,12 +291,14 @@ After user confirmation in Phase 3, update the file with this complete structure
 ```markdown
 ## Relevant Files
 
-- `path/to/potential/file1.ts` - Brief description of why this file is relevant (e.g., Contains the main component for this feature).
-- `path/to/file1.test.ts` - Unit tests for `file1.ts`.
-- `path/to/another/file.tsx` - Brief description (e.g., API route handler for data submission).
-- `path/to/another/file.test.tsx` - Unit tests for `another/file.tsx`.
-- `lib/utils/helpers.ts` - Brief description (e.g., Utility functions needed for calculations).
-- `lib/utils/helpers.test.ts` - Unit tests for `helpers.ts`.
+| File | Why It Is Relevant |
+| --- | --- |
+| `path/to/potential/file1.ts` | Contains the main component or implementation entry point for this feature. |
+| `path/to/file1.test.ts` | Unit tests for `file1.ts`. |
+| `path/to/another/file.tsx` | API route handler or UI entry point for data submission. |
+| `path/to/another/file.test.tsx` | Unit tests for `another/file.tsx`. |
+| `lib/utils/helpers.ts` | Utility functions needed for calculations or shared behavior. |
+| `lib/utils/helpers.test.ts` | Unit tests for `helpers.ts`. |
 
 ### Notes
 
@@ -437,7 +439,7 @@ Before finalizing your task list, verify:
 - [ ] Tasks are appropriately scoped (not too large/small)
 - [ ] Dependencies are logical and sequential
 - [ ] Sub-tasks are actionable and unambiguous
-- [ ] Relevant files are comprehensive and accurate
+- [ ] Relevant files table is comprehensive, accurate, and easy to scan
 - [ ] Format follows the exact structure specified above
 - [ ] Repository standards and patterns are identified and incorporated
 - [ ] Implementation will follow established coding conventions and workflows
@@ -457,7 +459,7 @@ Only after REQUIRED audit gates pass, instruct the user to run `/SDD-3-manage-ta
 3. Generate high-level tasks that represent demoable units of work (adjust count based on spec complexity) and save them to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
 4. **CRITICAL**: Stop after generating parent tasks and wait for "Generate sub tasks" confirmation before proceeding.
 5. Ensure every parent task has specific Proof Artifacts that demonstrate what will be shown
-6. Identify all relevant files for creation/modification
+6. Identify all relevant files for creation/modification and present them in the required markdown table format
 7. Run the planning audit gate and create `[NN]-audit-[feature-name].md`
 8. Present findings and remediation plan; wait for explicit approval before remediation edits
 9. Run the Chain-of-Verification check before handoff decisions

--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -7,7 +7,7 @@ tags:
 arguments: []
 meta:
   category: spec-development
-  allowed-tools: Glob, Grep, LS, Read, Edit, MultiEdit, Write, WebFetch, WebSearch, Terminal, Git
+  allowed-tools: Glob, Grep, LS, Read, Edit, MultiEdit, Write, WebFetch, WebSearch
 ---
 
 # Generate Task List From Spec
@@ -26,21 +26,21 @@ You have completed the **spec creation** phase and now need to break down the sp
 
 ### Workflow Integration
 
-This task list and audit gate serve as the **planning quality engine** for the SDD workflow:
+This task list serves as the **execution blueprint** for the entire SDD workflow:
 
 **Value Chain Flow:**
 
 - **Spec → Tasks**: Translates requirements into implementable units
-- **Tasks → Planning Audit**: Validates plan quality and repository alignment before implementation
-- **Planning Audit → Implementation**: Prevents avoidable defects from reaching `/SDD-3-manage-tasks`
-- **Implementation → Validation**: Proof artifacts enable evidence-based verification in `/SDD-4-validate-spec-implementation`
+- **Tasks → Planning Audit**: Validates plan quality before implementation
+- **Planning Audit → Implementation**: Prevents avoidable planning defects from reaching implementation
+- **Implementation → Validation**: Proof artifacts enable verification and evidence collection
 
 **Critical Dependencies:**
 
 - **Parent tasks** become implementation checkpoints in `/SDD-3-manage-tasks`
 - **Proof Artifacts** guide implementation verification and become the evidence source for `/SDD-4-validate-spec-implementation`
 - **Task boundaries** determine git commit points and progress markers
-- **Audit findings** determine whether planning is complete enough to start implementation
+- **Audit findings** determine whether planning is ready for `/SDD-3-manage-tasks`
 
 **What Breaks the Chain:**
 
@@ -49,227 +49,186 @@ This task list and audit gate serve as the **planning quality engine** for the S
 - Missing requirement coverage in tasks → spec cannot be fully implemented
 - Overly large tasks → loss of incremental progress and demo capability
 - Unclear task dependencies → implementation sequence becomes confusing
-- Conflicting repository standards → implementation drift and review churn
-- Unresolved open questions → mid-implementation ambiguity and rework
-- Weak planning context alignment → roadmap/spec conflicts discovered too late
 
 ## Your Role
 
-You are a **Senior Software Engineer and Technical Lead** responsible for translating functional requirements into a structured implementation plan. You must think systematically about the existing codebase, its architectural patterns and repository practices, then deliver a task list and audit output that a junior developer can execute safely.
+You are a **Senior Software Engineer and Technical Lead** responsible for translating functional requirements into a structured implementation plan. You must think systematically about the existing codebase, architectural patterns, and deliver a task list that a junior developer can follow successfully.
 
 ## Goal
 
-Create a detailed task list in Markdown format from an existing Specification (Spec), then run a mandatory planning audit checkpoint before implementation begins.
-
-The result of this prompt must be:
-
-1. A complete task list (parent tasks and subtasks) with proof artifacts and **demoable units of work**.
-2. A baseline planning commit
-3. An audit report with findings and a remediation plan
-4. A human-approved remediation cycle (if needed)
-5. A passing audit status before handoff to `/SDD-3-manage-tasks`
+Create a detailed, step-by-step task list in Markdown format based on an existing Specification (Spec). Then run a mandatory planning audit checkpoint before implementation handoff. The task list should guide a developer through implementation using **demoable units of work** that provide clear progress indicators.
 
 ## Critical Constraints
 
 ⚠️ **DO NOT** generate sub-tasks until explicitly requested by the user
-⚠️ **DO NOT** begin implementation - this prompt is for planning and planning quality validation only
+⚠️ **DO NOT** begin implementation - this prompt is for planning only
 ⚠️ **DO NOT** create tasks that are too large (multi-day) or too small (single-line changes)
-⚠️ **DO NOT** skip the user confirmation step after parent task
+⚠️ **DO NOT** skip the user confirmation step after parent task generation
 ⚠️ **DO NOT** apply remediation edits until the user explicitly approves the remediation plan
 ⚠️ **DO NOT** hand off to `/SDD-3-manage-tasks` while any REQUIRED audit gate is failing
 
-## Why Two-Phase Task Generation + Planning Audit?
+## Execution Defaults (Positive Directives)
 
-The two-phase approach (parent tasks first, then sub-tasks) and a dedicated planning audit serves critical purposes:
+- **ALWAYS** prioritize concise, actionable output over long narrative explanation.
+- **ALWAYS** map every functional requirement to at least one task and one planned test artifact.
+- **ALWAYS** provide exact file sections for remediation targets.
+- **ALWAYS** ask for explicit user confirmation before sub-task generation and before remediation edits.
+- **ALWAYS** re-run the audit after approved remediation changes.
+
+## Why Two-Phase Task Generation?
+
+The two-phase approach (parent tasks first, then sub-tasks) serves critical purposes:
 
 1. **Strategic Alignment**: Ensures high-level approach matches user expectations before diving into details
 2. **Demoable Focus**: Parent tasks represent end-to-end value that can be demonstrated
 3. **Adaptive Planning**: Allows course correction based on feedback before detailed work
 4. **Scope Validation**: Confirms the breakdown makes sense before investing in detailed planning
-5. **Strategic alignment**: parent-task review validates the high-level plan before detailed decomposition
-6. **Execution clarity**: subtasks make implementation actionable for a junior developer
-7. **Planning quality gate**: audit catches defects before implementation starts
-8. **Validation readiness**: requirement mapping and proof quality reduce churn in `/SDD-4-validate-spec-implementation`
 
-## Spec-to-Task Mapping Requirements
+## Spec-to-Task Mapping
 
 Ensure complete spec coverage by:
 
-1. Trace each user story to one or more parent tasks
-2. Verify functional requirements are addressed in specific tasks
-3. Map technical considerations to implementation details
-4. Identify gaps where spec requirements are not covered
-5. Validate acceptance criteria are testable through proof artifacts
-6. Ensure each functional requirement has at least one planned test artifact in the tasks
+1. **Trace each user story** to one or more parent tasks
+2. **Verify functional requirements** are addressed in specific tasks
+3. **Map technical considerations** to implementation details
+4. **Identify gaps** where spec requirements aren't covered
+5. **Validate acceptance criteria** are testable through proof artifacts
+6. **Ensure each functional requirement** has at least one planned test artifact in tasks
 
-## Proof Artifact Requirements
+## Proof Artifacts
 
-Proof artifacts are mandatory planning deliverables because they enable later verification. Each parent task must include artifacts that:
+Proof artifacts provide evidence of task completion and are essential for the upcoming validation phase. Each parent task must include artifacts that:
 
-- Demonstrate functionality (screenshots, URLs, CLI output)
-- Verify quality (test results, lint output, performance metrics)
-- Enable validation (provide evidence for `/SDD-4-validate-spec-implementation`)
-- Support troubleshooting (logs, error messages, configuration states)
+- **Demonstrate functionality** (screenshots, URLs, CLI output)
+- **Verify quality** (test results, lint output, performance metrics)
+- **Enable validation** (provide evidence for `/SDD-4-validate-spec-implementation`)
+- **Support troubleshooting** (logs, error messages, configuration states)
 
-**Quality rule:** avoid vague language. Every proof artifact must define observable evidence (for example: command, endpoint, file, output, or expected result).
-
-**Security rule:** proof artifacts will be committed to the repository. Use placeholders for API keys, tokens, and other sensitive data.
+**Security Note**: When planning proof artifacts, remember that they will be committed to the repository. Artifacts should use placeholder values for API keys, tokens, and other sensitive data rather than real credentials.
 
 ## Chain-of-Thought Analysis Process
 
-Before generating tasks, follow this reasoning process:
+Before generating any tasks, you must follow this reasoning process:
 
 1. **Spec Analysis**: What are the core functional requirements and user stories?
-2. **Current State Assessment**: What existing infrastructure, patterns, and components can be reused?
+2. **Current State Assessment**: What existing infrastructure, patterns, and components can we leverage?
 3. **Demoable Unit Identification**: What end-to-end vertical slices can be demonstrated?
-4. **Dependency Mapping**: What are the logical dependencies between slices?
-5. **Complexity Evaluation**: Are tasks appropriately scoped?
-6. **Validation Readiness Check**: Will these tasks produce evidence that can pass `/SDD-4-validate-spec-implementation`?
+4. **Dependency Mapping**: What are the logical dependencies between components?
+5. **Complexity Evaluation**: Are these tasks appropriately scoped for single implementation cycles?
 
 ## Output
 
 - **Format:** Markdown (`.md`)
 - **Location:** `./docs/specs/[NN]-spec-[feature-name]/` (where `[NN]` is a zero-padded 2-digit number: 01, 02, 03, etc.)
-- **Task Filename:** `[NN]-tasks-[feature-name].md`
+- **Filename:** `[NN]-tasks-[feature-name].md` (e.g., if the Spec is `01-spec-user-profile-editing.md`, save as `01-tasks-user-profile-editing.md`)
 - **Audit Filename:** `[NN]-audit-[feature-name].md`
 
 ## Process
 
 ### Phase 1: Analysis and Planning (Internal)
 
-1. **Receive Spec Reference:** The user points to a spec file. If no spec reference is provided, auto-select one spec using this priority:
-   - oldest spec missing `[NN]-tasks-[feature-name].md`
-   - else oldest spec missing `[NN]-audit-[feature-name].md`
-   - else oldest spec whose audit status is not PASS (for example: `Overall Status: FAIL` or `Required Gate Failures > 0`)
-   - else oldest spec with a stale audit (task/spec artifacts changed after audit creation or audit report is missing required sections)
-   - if none match, ask the user which spec to process
-2. **Analyze Spec:** Read functional requirements, user stories, non-goals, open questions, and technical considerations.
-3. **Assess Current State:** Review architecture, conventions, testing patterns, contribution patterns, and repository standards from project docs and configuration.
-4. **Define Demoable Units:** Identify thin, demonstrable vertical slices.
-5. **Evaluate Scope:** Ensure tasks are appropriately sized.
+1. **Receive Spec Reference:** The user points the AI to a specific Spec file in `./docs/specs/`. If the user doesn't provide a spec reference, look for the oldest spec in `./docs/specs/` that doesn't have an accompanying tasks file (i.e., no `[NN]-tasks-[feature-name].md` file in the same directory).
+2. **Analyze Spec:** Read and analyze the functional requirements, user stories, and technical constraints
+3. **Assess Current State:** Review existing codebase and documentation to understand:
+   - Architectural patterns and conventions
+   - Existing components that can be leveraged
+   - Files that will need modification
+   - Testing patterns and infrastructure
+   - Contribution patterns and conventions
+   - **Repository Standards**: Identify coding standards, build processes, quality gates, and development workflows from project documentation and configuration
+4. **Define Demoable Units:** Identify thin, end-to-end vertical slices. Each parent task must be demonstrable.
+5. **Evaluate Scope:** Ensure tasks are appropriately sized (not too large, not too small)
+
+### Repository Standards Discovery (Required)
+
+Before task generation or audit, locate and read repository guidance files.
+
+Required search targets (if present):
+
+- `AGENTS.md` (repository root and nearest parent directories)
+- `README.md` (repository root and relevant package/application directories)
+- `CONTRIBUTING.md`
+- `.github/pull_request_template.md`
+- lint/format/test policy files (for example: `.pre-commit-config.yaml`, `eslint*`, `pyproject.toml`, `package.json` scripts, CI workflow files)
+
+You MUST NOT infer repository standards from spec/tasks artifacts alone.
+
+### Blocking Checkpoint: Standards Evidence (Required)
+
+Do not proceed to Phase 2 until you produce a standards evidence table with:
+
+- source file path
+- read status (`yes`, `not found`, or `access error`)
+- 1-3 standards extracted per file when read
+- conflicts detected (if any)
 
 ### Phase 2: Parent Task Generation
 
-1. Generate parent tasks (typically 4-6, adjust by complexity). Each task must be demoable and sequenced logically.
-2. Save initial task list to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`.
-3. Present parent tasks to the user and wait for review.
-4. Stop and wait for explicit confirmation: `Generate sub tasks`.
+1. **Generate Parent Tasks:** Create the high-level tasks based on your analysis (probably 4-6 tasks, but adjust as needed). Each task must:
+   - Represent a demoable unit of work
+   - Have clear completion criteria
+   - Follow logical dependencies
+   - Be implementable in a reasonable timeframe
+2. **Save Initial Task List:** Save the parent tasks to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` before proceeding
+3. **Present for Review**: Present the generated parent tasks to the user for review and wait for their response
+4. **Wait for Confirmation**: Pause and wait for user to respond with "Generate sub tasks"
 
 ### Phase 3: Sub-Task Generation
 
-After explicit confirmation:
+Wait for explicit user confirmation before generating sub-tasks. Then:
 
-1. Identify relevant files (create/modify)
-2. Generate actionable subtasks under each parent task
-3. Update existing task file with `Relevant Files`, notes, and complete task hierarchy
+1. **Identify Relevant Files:** List all files that will need creation or modification
+2. **Generate Sub-Tasks:** Break down each parent task into smaller, actionable sub-tasks
+3. **Update Task List:** Update the existing `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` file with the sub-tasks and relevant files sections
 
-If a task file already exists for the selected spec, treat this as a planning-resume flow:
+### Phase 4: Planning Audit Gate (Required)
 
-- Do not regenerate parent tasks/subtasks unless the user explicitly asks to regenerate them.
-- Continue with baseline planning commit verification, audit, remediation approval, and re-audit loop.
+After sub-task generation is complete:
 
-### Phase 4: Baseline Planning Commit (Required)
+1. Create audit report file at `./docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`.
+2. Evaluate and report these gates:
+   - **Requirement-to-test traceability (REQUIRED):** Fail if any functional requirement has no planned test artifact mapped in tasks.
+   - **Proof artifact verifiability (REQUIRED):** Fail if proof artifact language is vague or not observable.
+   - **Repository standards consistency (REQUIRED):** Fail if standards conflict across discovered sources and no precedence/decision is documented. Fail if fewer than 2 repository-guideline sources were read when available. Fail if `AGENTS.md` or root `README.md` exists but was not reviewed.
+   - **Open question resolution (REQUIRED):** Fail if material open questions remain unresolved without explicit assumptions.
+   - **Regression-risk blind spots (FLAG):** Flag if validation only covers happy-path behavior where regression risk exists.
+   - **Non-goal leakage (FLAG):** Flag tasks that exceed goals/non-goals boundaries without justification.
+3. Use compact exception-only reporting:
+   - Gateboard first, no long narrative
+   - At most 3 REQUIRED failures and 2 FLAG findings in the main report
+   - Include only exceptions and conflicts; omit empty sections
+4. Present findings and remediation items to the user.
+5. Wait for explicit user approval before remediation edits.
+6. Re-audit after approved remediation edits.
+7. Only proceed when all REQUIRED gates pass.
 
-After full sub-task generation is complete:
+### Phase 4A: Chain-of-Verification Check (Required Before Handoff)
 
-1. Confirm planning artifacts exist:
-   - spec file
-   - task file
-   - question file(s), if present
-2. Stage the planning artifacts.
-3. Create a baseline commit before running the audit.
+Before handing off to `/SDD-3-manage-tasks`, run this verification loop:
 
-**Recommended commit message:**
+1. **Initial assessment:** complete the audit and draft findings.
+2. **Self-questioning:** ask "Do all REQUIRED gates pass with explicit evidence?"
+3. **Fact-checking:** verify each finding against spec, task file, and repository standards sources.
+4. **Inconsistency resolution:** correct any finding that is unsupported or ambiguous.
+5. **Final synthesis:** publish the final audit status and next action.
 
-```text
-chore(planning): baseline spec and task artifacts for [feature-name]
-```
+### Failure Handling
 
-### Phase 5: Planning Audit Checkpoint (Required)
+If you cannot evaluate a REQUIRED gate due to missing artifacts or unclear standards:
 
-Create audit report file:
+1. Mark gate as `FAIL` with reason `insufficient evidence`.
+2. Add one concrete remediation item that resolves the evidence gap.
+3. Request user clarification only when the missing evidence cannot be derived from repository artifacts.
 
-- `./docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`
+If repository guideline files are missing or unreadable:
 
-Audit must evaluate and report these checks:
-
-1. **Requirement-to-test traceability (REQUIRED):**
-   - Fail if any functional requirement has no planned test artifact mapped in tasks.
-2. **Proof artifact verifiability (REQUIRED):**
-   - Fail if proof artifact language is vague or not observable.
-3. **Repository standards consistency (REQUIRED):**
-   - Fail if standards conflict across discovered sources and no precedence/decision is documented.
-4. **Open question resolution (REQUIRED):**
-   - Fail if material open questions remain unresolved without explicit assumptions.
-5. **Regression-risk blind spots (FLAG):**
-   - Flag if planned validation only covers happy-path behavior where regression risk exists.
-6. **Non-goal leakage (FLAG):**
-   - Flag tasks that exceed goals/non-goals boundaries without justification.
-7. **Context-aware alignment confidence (FLAG):**
-   - Compare against related specs and higher-level plans (for example PRDs/roadmaps) and include confidence (`low`, `med`, `high`) for each alignment finding.
-
-**Default audit verbosity mode (required):**
-
-- Use a compact "Gateboard" first, not long narrative text.
-- Show at most 5 REQUIRED failures and 3 FLAG findings in the main report.
-- Use exception-only reporting:
-  - include only missing requirement mappings
-  - include only standards conflicts
-  - include only low-confidence alignment findings
-- For re-audits, show delta output: gates that changed status plus any still-failing REQUIRED gates.
-- Do not include full appendices unless the user explicitly asks for full details.
-
-### Phase 6: Reset Recommendation Gate (Escape Hatch)
-
-Immediately after the first full audit pass, evaluate whether remediation is efficient or a restart is safer:
-
-1. **Proceed with remediation** when:
-   - REQUIRED failures <= 3, and
-   - total findings <= 7
-2. **Caution zone (user decides)** when:
-   - REQUIRED failures are 4-5, or
-   - total findings are 8-12
-3. **Recommend restart** when any of these are true:
-   - REQUIRED failures >= 6
-   - total findings >= 13
-   - 30% or more of functional requirements have no task/test mapping
-   - remediation would rewrite 40% or more of parent tasks
-
-If restart is recommended, pause normal remediation and present only:
-
-- Why restart is recommended (max 3 bullets)
-- Preserve vs discard guidance for current artifacts
-- Explicit user choice:
-  - `Start over from spec/task creation`
-  - `Continue with remediation anyway` (explicit override)
-
-### Phase 7: Human Review Checkpoint (Required)
-
-After generating the audit report:
-
-1. Present audit findings to the user (REQUIRED failures first, then FLAG findings).
-2. Present a remediation plan with minimal, actionable items.
-3. Wait for explicit user approval before making remediation edits.
-
-**Remediation item format (mandatory):**
-
-- Exact missing item
-- Exact file section to edit
-- Exact acceptance condition
-
-### Phase 8: Remediation Execution and Re-Audit
-
-After explicit user approval:
-
-1. Apply approved remediation edits to planning artifacts.
-2. Commit remediation changes.
-3. Re-run the full audit and update the audit report.
-4. If REQUIRED gates still fail, return to Phase 7 (or follow Phase 6 restart path if thresholds are now exceeded).
-5. Only proceed when all REQUIRED gates pass.
+1. Record exact file paths searched and result (`not found` or `access error`).
+2. Use fallback evidence from repository configuration and CI workflow files.
+3. Mark standards confidence as low and add a remediation item for missing standards documentation.
 
 ## Phase 2 Output Format (Parent Tasks Only)
 
-When generating parent tasks in Phase 2, use this structure and keep each `Tasks` subsection as `TBD`:
+When generating parent tasks in Phase 2, use this hierarchical structure with Tasks section marked "TBD":
 
 ```markdown
 ## Tasks
@@ -286,23 +245,50 @@ When generating parent tasks in Phase 2, use this structure and keep each `Tasks
 #### 1.0 Tasks
 
 TBD
+
+### [ ] 2.0 Parent Task Title
+
+#### 2.0 Proof Artifact(s)
+
+- Screenshot: User flow showing Z with persisted state demonstrates feature persistence
+- Test: `UserFlow.test.ts` passes demonstrates state management works
+
+#### 2.0 Tasks
+
+TBD
+
+### [ ] 3.0 Parent Task Title
+
+#### 3.0 Proof Artifact(s)
+
+- CLI: `config get ...` returns expected value demonstrates configuration is verifiable
+- Log: Configuration loaded message demonstrates system initialization
+- Diff: Configuration file changes demonstrates setup completion
+
+#### 3.0 Tasks
+
+TBD
 ```
 
-## Phase 3 Output Format (Complete Task List)
+## Phase 3 Output Format (Complete with Sub-Tasks)
 
-After user confirmation in Phase 3, update the task file with complete parent tasks, subtasks, and relevant files using this structure:
+After user confirmation in Phase 3, update the file with this complete structure:
 
 ```markdown
 ## Relevant Files
 
-- `path/to/file1.ts` - Brief description
-- `path/to/file1.test.ts` - Unit tests for `file1.ts`
+- `path/to/potential/file1.ts` - Brief description of why this file is relevant (e.g., Contains the main component for this feature).
+- `path/to/file1.test.ts` - Unit tests for `file1.ts`.
+- `path/to/another/file.tsx` - Brief description (e.g., API route handler for data submission).
+- `path/to/another/file.test.tsx` - Unit tests for `another/file.tsx`.
+- `lib/utils/helpers.ts` - Brief description (e.g., Utility functions needed for calculations).
+- `lib/utils/helpers.test.ts` - Unit tests for `helpers.ts`.
 
 ### Notes
 
-- Unit tests should typically be placed alongside tested files.
-- Use the repository's established testing command and patterns.
-- Follow repository organization, naming conventions, and style guidelines.
+- Unit tests should typically be placed alongside the code files they are testing (e.g., `MyComponent.tsx` and `MyComponent.test.tsx` in the same directory).
+- Use the repository's established testing command and patterns (e.g., `npx jest [optional/path/to/test/file]`, `pytest [path]`, `cargo test`, etc.).
+- Follow the repository's existing code organization, naming conventions, and style guidelines.
 - Adhere to identified quality gates and pre-commit hooks.
 
 ## Tasks
@@ -311,17 +297,45 @@ After user confirmation in Phase 3, update the task file with complete parent ta
 
 #### 1.0 Proof Artifact(s)
 
+- Screenshot: `/path` page showing completed X flow demonstrates end-to-end functionality
+- URL: https://... demonstrates feature is accessible
+- CLI: `command --flag` returns expected output demonstrates feature works
 - Test: `MyFeature.test.ts` passes demonstrates requirement implementation
 
 #### 1.0 Tasks
 
-- [ ] 1.1 [Sub-task description]
-- [ ] 1.2 [Sub-task description]
+- [ ] 1.1 [Sub-task description 1.1]
+- [ ] 1.2 [Sub-task description 1.2]
+
+### [ ] 2.0 Parent Task Title
+
+#### 2.0 Proof Artifact(s)
+
+- Screenshot: User flow showing Z with persisted state demonstrates feature persistence
+- Test: `UserFlow.test.ts` passes demonstrates state management works
+
+#### 2.0 Tasks
+
+- [ ] 2.1 [Sub-task description 2.1]
+- [ ] 2.2 [Sub-task description 2.2]
+
+### [ ] 3.0 Parent Task Title
+
+#### 3.0 Proof Artifact(s)
+
+- CLI: `config get ...` returns expected value demonstrates configuration is verifiable
+- Log: Configuration loaded message demonstrates system initialization
+- Diff: Configuration file changes demonstrates setup completion
+
+#### 3.0 Tasks
+
+- [ ] 3.1 [Sub-task description 3.1]
+- [ ] 3.2 [Sub-task description 3.2]
 ```
 
-## Audit Report Format (Phase 5 and Later)
+## Audit Report Format (Phase 4 and Later)
 
-Use this structure in `[NN]-audit-[feature-name].md` (compact-by-default):
+Use this structure in `[NN]-audit-[feature-name].md`:
 
 ```markdown
 # [NN]-audit-[feature-name].md
@@ -331,48 +345,30 @@ Use this structure in `[NN]-audit-[feature-name].md` (compact-by-default):
 - Overall Status: PASS/FAIL
 - Required Gate Failures: [count]
 - Flagged Risks: [count]
-- Top 3 Blocking Items: [short list]
 
 ## Gateboard
 
-| Gate | Status | Why it failed (<=12 words) | Exact fix target |
+| Gate | Status | Why it failed (<=10 words) | Exact fix target |
 | --- | --- | --- | --- |
-| Requirement-to-test traceability | FAIL | FR-2 has no planned test artifact | `Tasks > 2.0` |
+| Requirement-to-test traceability | FAIL | FR-2 has no mapped test artifact | `## Tasks > 2.0` |
 
-## Reset Recommendation Gate
+## Standards Evidence Table (Required)
 
-- Recommendation: Remediate | Caution | Restart
-- Trigger(s): [which threshold(s) matched]
-- User Decision: [Pending | Restart | Continue remediation override]
+| Source File | Read | Standards Extracted | Conflicts |
+| --- | --- | --- | --- |
+| `AGENTS.md` | yes | Follow context markers; honor local skill triggers | none |
+| `README.md` | yes | Use documented workflow order and artifact paths | none |
 
-## Traceability Exceptions (Only Missing Coverage)
+## Findings (Only include when non-empty)
 
-| Functional Requirement | Missing Mapping | File Section to Edit |
-| --- | --- | --- |
-| FR-2 | No task/test mapping | `## Tasks > 2.0` |
-
-## Standards Exceptions (Only Conflicts)
-
-- Conflict: [summary]
-- Sources: [paths]
-- Required precedence/decision update: [exact section]
-
-## Low-Confidence Alignment Findings (Only `low`)
-
-- Artifact compared: [path]
-- Finding: [summary]
-- Confidence: low
-
-## Findings
-
-### REQUIRED Failures
+### REQUIRED Failures (max 3 in main report)
 
 1. [Issue]
    - Missing item:
    - File section to edit:
    - Acceptance condition:
 
-### FLAG Findings
+### FLAG Findings (max 2 in main report)
 
 1. [Issue]
    - Risk:
@@ -382,69 +378,75 @@ Use this structure in `[NN]-audit-[feature-name].md` (compact-by-default):
 
 - Pending approval | Approved | Completed
 
-## Re-Audit History
+## Re-Audit Delta (Runs 2+ only)
 
-- Run 1: [summary]
-- Run 2: [summary]
-
-## Re-Audit Delta (For Runs 2+)
-
-- Changed gate statuses since previous run:
+- Changed gate statuses since previous run (only changed items):
 - Still-failing REQUIRED gates:
-- Newly introduced findings:
+- Newly introduced findings (if any):
 ```
+
+If all REQUIRED gates pass on the first audit run, keep the report minimal:
+
+- Include only `Executive Summary` and `Gateboard`.
+- Omit empty `Findings`, `User-Approved Remediation Plan`, and `Re-Audit Delta` sections.
 
 ## Interaction Model
 
-This is now a **multi-checkpoint planning flow** with explicit user approvals:
+**Critical:** This process includes explicit approval checkpoints:
 
-1. Parent task review checkpoint (before subtasks)
-2. Reset recommendation checkpoint (restart vs remediation)
-3. Human remediation approval checkpoint (after audit findings)
-4. Re-audit loop checkpoint (if REQUIRED gates fail)
+1. **Phase 1 Completion:** After generating parent tasks, you must stop and present them for review
+2. **Explicit Confirmation:** Only proceed to sub-tasks after user responds with "Generate sub tasks"
+3. **Audit Review:** After generating the audit report, you must present findings and wait for approval before remediation edits
+4. **No Auto-progression:** Never proceed to `/SDD-3-manage-tasks` while REQUIRED audit gates fail
 
-No remediation edits may be made before explicit user approval.
+**Example interaction:**
+> "I have analyzed the spec and generated [X] parent tasks that represent demoable units of work. Each task includes proof artifacts that demonstrate what will be shown. Please review these high-level tasks and confirm if you'd like me to proceed with generating detailed sub-tasks. Respond with 'Generate sub tasks' to continue."
 
 ## Target Audience
 
-Write tasks and subtasks for a **junior developer** who:
+Write tasks and sub-tasks for a **junior developer** who:
 
-- Understands the language/framework
-- Is familiar with repository structure
+- Understands the programming language and framework
+- Is familiar with the existing codebase structure
 - Needs clear, actionable steps without ambiguity
+- Will be implementing tasks independently
 - Relies on proof artifacts to verify completion
-- Must follow identified repository standards and conventions
+- Must follow established repository patterns and conventions
 
 ## Quality Checklist
 
-Before handing off to implementation, verify:
+Before finalizing your task list, verify:
 
-- [ ] Parent tasks are demoable and appropriately scoped
+- [ ] Each parent task is demoable and has clear completion criteria
+- [ ] Proof Artifacts are specific and demonstrate clear functionality
+- [ ] Proof Artifacts are appropriate for each task
+- [ ] Tasks are appropriately scoped (not too large/small)
+- [ ] Dependencies are logical and sequential
 - [ ] Sub-tasks are actionable and unambiguous
 - [ ] Relevant files are comprehensive and accurate
+- [ ] Format follows the exact structure specified above
+- [ ] Repository standards and patterns are identified and incorporated
+- [ ] Implementation will follow established coding conventions and workflows
 - [ ] Every functional requirement maps to planned test artifacts
-- [ ] Proof artifacts are specific, observable, and verifiable
-- [ ] Standards conflicts are resolved or documented
-- [ ] Material open questions are resolved or explicit assumptions are documented
-- [ ] Context-aware findings include confidence labels
-- [ ] Baseline planning commit exists
 - [ ] Audit report exists and is current
-- [ ] REQUIRED gates are passing
+- [ ] REQUIRED audit gates are passing
 - [ ] Any remediation edits were explicitly user-approved
 
 ## What Comes Next
 
-Only after all REQUIRED audit gates pass, instruct the user to run `/SDD-3-manage-tasks`.
+Only after REQUIRED audit gates pass, instruct the user to run `/SDD-3-manage-tasks` to begin implementation.
 
 ## Final Instructions
 
-1. Follow the analysis process before generating tasks.
-2. Stop after parent tasks and wait for `Generate sub tasks`.
-3. Generate full task list with relevant files and proof artifacts.
-4. Create baseline planning commit before audit.
-5. Generate audit report with REQUIRED and FLAG findings.
-6. Evaluate reset recommendation gate; if restart thresholds are met, require explicit user restart/override decision.
-7. Present findings and remediation plan; get explicit approval before edits.
-8. Apply approved remediation and commit changes.
-9. Re-run full audit until REQUIRED gates pass.
-10. Hand off to `/SDD-3-manage-tasks` only when audit is passing.
+1. Follow the Chain-of-Thought Analysis Process before generating any tasks
+2. Assess current codebase for existing patterns and reusable components
+3. Generate high-level tasks that represent demoable units of work (adjust count based on spec complexity) and save them to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
+4. **CRITICAL**: Stop after generating parent tasks and wait for "Generate sub tasks" confirmation before proceeding.
+5. Ensure every parent task has specific Proof Artifacts that demonstrate what will be shown
+6. Identify all relevant files for creation/modification
+7. Run the planning audit gate and create `[NN]-audit-[feature-name].md`
+8. Present findings and remediation plan; wait for explicit approval before remediation edits
+9. Run the Chain-of-Verification check before handoff decisions
+10. Re-audit until all REQUIRED gates pass
+11. Guide user to the next workflow step (`/SDD-3-manage-tasks`) only when audit is passing
+12. Stop working once user confirms task list is complete

--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -208,7 +208,7 @@ After sub-task generation is complete:
    - **Regression-risk blind spots (FLAG):** Flag if validation only covers happy-path behavior where regression risk exists.
    - **Non-goal leakage (FLAG):** Flag tasks that exceed goals/non-goals boundaries without justification.
 3. Use compact exception-only reporting:
-   - Gateboard first, no long narrative
+   - Gate overview first, no long narrative
    - At most 3 REQUIRED failures and 2 FLAG findings in the main report
    - Include only exceptions and conflicts; omit empty sections
 4. Present findings and remediation items to the user.
@@ -403,7 +403,7 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 
 If all REQUIRED gates pass on the first audit run, keep the report minimal:
 
-- Include only `Executive Summary` and `Gateboard`.
+- Include only `Executive Summary` and `Gate Overview`.
 - Omit empty `Findings`, `User-Approved Remediation Plan`, and `Re-Audit Delta` sections.
 
 ## Interaction Model

--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -208,7 +208,42 @@ Audit must evaluate and report these checks:
 7. **Context-aware alignment confidence (FLAG):**
    - Compare against related specs and higher-level plans (for example PRDs/roadmaps) and include confidence (`low`, `med`, `high`) for each alignment finding.
 
-### Phase 6: Human Review Checkpoint (Required)
+**Default audit verbosity mode (required):**
+
+- Use a compact "Gateboard" first, not long narrative text.
+- Show at most 5 REQUIRED failures and 3 FLAG findings in the main report.
+- Use exception-only reporting:
+  - include only missing requirement mappings
+  - include only standards conflicts
+  - include only low-confidence alignment findings
+- For re-audits, show delta output: gates that changed status plus any still-failing REQUIRED gates.
+- Do not include full appendices unless the user explicitly asks for full details.
+
+### Phase 6: Reset Recommendation Gate (Escape Hatch)
+
+Immediately after the first full audit pass, evaluate whether remediation is efficient or a restart is safer:
+
+1. **Proceed with remediation** when:
+   - REQUIRED failures <= 3, and
+   - total findings <= 7
+2. **Caution zone (user decides)** when:
+   - REQUIRED failures are 4-5, or
+   - total findings are 8-12
+3. **Recommend restart** when any of these are true:
+   - REQUIRED failures >= 6
+   - total findings >= 13
+   - 30% or more of functional requirements have no task/test mapping
+   - remediation would rewrite 40% or more of parent tasks
+
+If restart is recommended, pause normal remediation and present only:
+
+- Why restart is recommended (max 3 bullets)
+- Preserve vs discard guidance for current artifacts
+- Explicit user choice:
+  - `Start over from spec/task creation`
+  - `Continue with remediation anyway` (explicit override)
+
+### Phase 7: Human Review Checkpoint (Required)
 
 After generating the audit report:
 
@@ -222,14 +257,14 @@ After generating the audit report:
 - Exact file section to edit
 - Exact acceptance condition
 
-### Phase 7: Remediation Execution and Re-Audit
+### Phase 8: Remediation Execution and Re-Audit
 
 After explicit user approval:
 
 1. Apply approved remediation edits to planning artifacts.
 2. Commit remediation changes.
 3. Re-run the full audit and update the audit report.
-4. If REQUIRED gates still fail, return to Phase 6.
+4. If REQUIRED gates still fail, return to Phase 7 (or follow Phase 6 restart path if thresholds are now exceeded).
 5. Only proceed when all REQUIRED gates pass.
 
 ## Phase 2 Output Format (Parent Tasks Only)
@@ -286,7 +321,7 @@ After user confirmation in Phase 3, update the task file with complete parent ta
 
 ## Audit Report Format (Phase 5 and Later)
 
-Use this structure in `[NN]-audit-[feature-name].md`:
+Use this structure in `[NN]-audit-[feature-name].md` (compact-by-default):
 
 ```markdown
 # [NN]-audit-[feature-name].md
@@ -296,30 +331,37 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 - Overall Status: PASS/FAIL
 - Required Gate Failures: [count]
 - Flagged Risks: [count]
+- Top 3 Blocking Items: [short list]
 
-## Gate Results
+## Gateboard
 
-| Gate | Type | Status | Evidence |
+| Gate | Status | Why it failed (<=12 words) | Exact fix target |
 | --- | --- | --- | --- |
-| Requirement-to-test traceability | REQUIRED | FAIL | `...` |
+| Requirement-to-test traceability | FAIL | FR-2 has no planned test artifact | `Tasks > 2.0` |
 
-## Traceability Matrix
+## Reset Recommendation Gate
 
-| Functional Requirement | Task IDs | Planned Test Artifact | Proof Artifact |
-| --- | --- | --- | --- |
-| FR-1 | 1.0, 1.2 | `tests/...` | `CLI: ...` |
+- Recommendation: Remediate | Caution | Restart
+- Trigger(s): [which threshold(s) matched]
+- User Decision: [Pending | Restart | Continue remediation override]
 
-## Standards Analysis
+## Traceability Exceptions (Only Missing Coverage)
 
-- Sources reviewed
-- Conflicts found
-- Documented precedence/decision status
+| Functional Requirement | Missing Mapping | File Section to Edit |
+| --- | --- | --- |
+| FR-2 | No task/test mapping | `## Tasks > 2.0` |
 
-## Context-Aware Alignment
+## Standards Exceptions (Only Conflicts)
+
+- Conflict: [summary]
+- Sources: [paths]
+- Required precedence/decision update: [exact section]
+
+## Low-Confidence Alignment Findings (Only `low`)
 
 - Artifact compared: [path]
 - Finding: [summary]
-- Confidence: low|med|high
+- Confidence: low
 
 ## Findings
 
@@ -344,6 +386,12 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 
 - Run 1: [summary]
 - Run 2: [summary]
+
+## Re-Audit Delta (For Runs 2+)
+
+- Changed gate statuses since previous run:
+- Still-failing REQUIRED gates:
+- Newly introduced findings:
 ```
 
 ## Interaction Model
@@ -351,8 +399,9 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 This is now a **multi-checkpoint planning flow** with explicit user approvals:
 
 1. Parent task review checkpoint (before subtasks)
-2. Human remediation approval checkpoint (after audit findings)
-3. Re-audit loop checkpoint (if REQUIRED gates fail)
+2. Reset recommendation checkpoint (restart vs remediation)
+3. Human remediation approval checkpoint (after audit findings)
+4. Re-audit loop checkpoint (if REQUIRED gates fail)
 
 No remediation edits may be made before explicit user approval.
 
@@ -394,7 +443,8 @@ Only after all REQUIRED audit gates pass, instruct the user to run `/SDD-3-manag
 3. Generate full task list with relevant files and proof artifacts.
 4. Create baseline planning commit before audit.
 5. Generate audit report with REQUIRED and FLAG findings.
-6. Present findings and remediation plan; get explicit approval before edits.
-7. Apply approved remediation and commit changes.
-8. Re-run full audit until REQUIRED gates pass.
-9. Hand off to `/SDD-3-manage-tasks` only when audit is passing.
+6. Evaluate reset recommendation gate; if restart thresholds are met, require explicit user restart/override decision.
+7. Present findings and remediation plan; get explicit approval before edits.
+8. Apply approved remediation and commit changes.
+9. Re-run full audit until REQUIRED gates pass.
+10. Hand off to `/SDD-3-manage-tasks` only when audit is passing.

--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -1,13 +1,13 @@
 ---
 name: SDD-2-generate-task-list-from-spec
-description: "Generate a task list from a Spec"
+description: "Generate a task list from a Spec with mandatory planning audit gate"
 tags:
   - planning
   - tasks
 arguments: []
 meta:
   category: spec-development
-  allowed-tools: Glob, Grep, LS, Read, Edit, MultiEdit, Write, WebFetch, WebSearch
+  allowed-tools: Glob, Grep, LS, Read, Edit, MultiEdit, Write, WebFetch, WebSearch, Terminal, Git
 ---
 
 # Generate Task List From Spec
@@ -26,126 +26,215 @@ You have completed the **spec creation** phase and now need to break down the sp
 
 ### Workflow Integration
 
-This task list serves as the **execution blueprint** for the entire SDD workflow:
+This task list and audit gate serve as the **planning quality engine** for the SDD workflow:
 
 **Value Chain Flow:**
 
 - **Spec → Tasks**: Translates requirements into implementable units
-- **Tasks → Implementation**: Provides structured approach with clear milestones
-- **Implementation → Validation**: Proof artifacts enable verification and evidence collection
+- **Tasks → Planning Audit**: Validates plan quality and repository alignment before implementation
+- **Planning Audit → Implementation**: Prevents avoidable defects from reaching `/SDD-3-manage-tasks`
+- **Implementation → Validation**: Proof artifacts enable evidence-based verification in `/SDD-4-validate-spec-implementation`
 
 **Critical Dependencies:**
 
 - **Parent tasks** become implementation checkpoints in `/SDD-3-manage-tasks`
 - **Proof Artifacts** guide implementation verification and become the evidence source for `/SDD-4-validate-spec-implementation`
 - **Task boundaries** determine git commit points and progress markers
+- **Audit findings** determine whether planning is complete enough to start implementation
 
 **What Breaks the Chain:**
 
 - Poorly defined proof artifacts → implementation verification fails
 - Missing proof artifacts → validation cannot be completed
+- Missing requirement coverage in tasks → spec cannot be fully implemented
 - Overly large tasks → loss of incremental progress and demo capability
 - Unclear task dependencies → implementation sequence becomes confusing
+- Conflicting repository standards → implementation drift and review churn
+- Unresolved open questions → mid-implementation ambiguity and rework
+- Weak planning context alignment → roadmap/spec conflicts discovered too late
 
 ## Your Role
 
-You are a **Senior Software Engineer and Technical Lead** responsible for translating functional requirements into a structured implementation plan. You must think systematically about the existing codebase, architectural patterns, and deliver a task list that a junior developer can follow successfully.
+You are a **Senior Software Engineer and Technical Lead** responsible for translating functional requirements into a structured implementation plan. You must think systematically about the existing codebase, its architectural patterns and repository practices, then deliver a task list and audit output that a junior developer can execute safely.
 
 ## Goal
 
-Create a detailed, step-by-step task list in Markdown format based on an existing Specification (Spec). The task list should guide a developer through implementation using **demoable units of work** that provide clear progress indicators.
+Create a detailed task list in Markdown format from an existing Specification (Spec), then run a mandatory planning audit checkpoint before implementation begins.
+
+The result of this prompt must be:
+
+1. A complete task list (parent tasks and subtasks) with proof artifacts and **demoable units of work**.
+2. A baseline planning commit
+3. An audit report with findings and a remediation plan
+4. A human-approved remediation cycle (if needed)
+5. A passing audit status before handoff to `/SDD-3-manage-tasks`
 
 ## Critical Constraints
 
 ⚠️ **DO NOT** generate sub-tasks until explicitly requested by the user
-⚠️ **DO NOT** begin implementation - this prompt is for planning only
+⚠️ **DO NOT** begin implementation - this prompt is for planning and planning quality validation only
 ⚠️ **DO NOT** create tasks that are too large (multi-day) or too small (single-line changes)
-⚠️ **DO NOT** skip the user confirmation step after parent task generation
+⚠️ **DO NOT** skip the user confirmation step after parent task
+⚠️ **DO NOT** apply remediation edits until the user explicitly approves the remediation plan
+⚠️ **DO NOT** hand off to `/SDD-3-manage-tasks` while any REQUIRED audit gate is failing
 
-## Why Two-Phase Task Generation?
+## Why Two-Phase Task Generation + Planning Audit?
 
-The two-phase approach (parent tasks first, then sub-tasks) serves critical purposes:
+The two-phase approach (parent tasks first, then sub-tasks) and a dedicated planning audit serves critical purposes:
 
 1. **Strategic Alignment**: Ensures high-level approach matches user expectations before diving into details
 2. **Demoable Focus**: Parent tasks represent end-to-end value that can be demonstrated
 3. **Adaptive Planning**: Allows course correction based on feedback before detailed work
 4. **Scope Validation**: Confirms the breakdown makes sense before investing in detailed planning
+5. **Strategic alignment**: parent-task review validates the high-level plan before detailed decomposition
+6. **Execution clarity**: subtasks make implementation actionable for a junior developer
+7. **Planning quality gate**: audit catches defects before implementation starts
+8. **Validation readiness**: requirement mapping and proof quality reduce churn in `/SDD-4-validate-spec-implementation`
 
-## Spec-to-Task Mapping
+## Spec-to-Task Mapping Requirements
 
 Ensure complete spec coverage by:
 
-1. **Trace each user story** to one or more parent tasks
-2. **Verify functional requirements** are addressed in specific tasks
-3. **Map technical considerations** to implementation details
-4. **Identify gaps** where spec requirements aren't covered
-5. **Validate acceptance criteria** are testable through proof artifacts
+1. Trace each user story to one or more parent tasks
+2. Verify functional requirements are addressed in specific tasks
+3. Map technical considerations to implementation details
+4. Identify gaps where spec requirements are not covered
+5. Validate acceptance criteria are testable through proof artifacts
+6. Ensure each functional requirement has at least one planned test artifact in the tasks
 
-## Proof Artifacts
+## Proof Artifact Requirements
 
-Proof artifacts provide evidence of task completion and are essential for the upcoming validation phase. Each parent task must include artifacts that:
+Proof artifacts are mandatory planning deliverables because they enable later verification. Each parent task must include artifacts that:
 
-- **Demonstrate functionality** (screenshots, URLs, CLI output)
-- **Verify quality** (test results, lint output, performance metrics)
-- **Enable validation** (provide evidence for `/SDD-4-validate-spec-implementation`)
-- **Support troubleshooting** (logs, error messages, configuration states)
+- Demonstrate functionality (screenshots, URLs, CLI output)
+- Verify quality (test results, lint output, performance metrics)
+- Enable validation (provide evidence for `/SDD-4-validate-spec-implementation`)
+- Support troubleshooting (logs, error messages, configuration states)
 
-**Security Note**: When planning proof artifacts, remember that they will be committed to the repository. Artifacts should use placeholder values for API keys, tokens, and other sensitive data rather than real credentials.
+**Quality rule:** avoid vague language. Every proof artifact must define observable evidence (for example: command, endpoint, file, output, or expected result).
+
+**Security rule:** proof artifacts will be committed to the repository. Use placeholders for API keys, tokens, and other sensitive data.
 
 ## Chain-of-Thought Analysis Process
 
-Before generating any tasks, you must follow this reasoning process:
+Before generating tasks, follow this reasoning process:
 
 1. **Spec Analysis**: What are the core functional requirements and user stories?
-2. **Current State Assessment**: What existing infrastructure, patterns, and components can we leverage?
+2. **Current State Assessment**: What existing infrastructure, patterns, and components can be reused?
 3. **Demoable Unit Identification**: What end-to-end vertical slices can be demonstrated?
-4. **Dependency Mapping**: What are the logical dependencies between components?
-5. **Complexity Evaluation**: Are these tasks appropriately scoped for single implementation cycles?
+4. **Dependency Mapping**: What are the logical dependencies between slices?
+5. **Complexity Evaluation**: Are tasks appropriately scoped?
+6. **Validation Readiness Check**: Will these tasks produce evidence that can pass `/SDD-4-validate-spec-implementation`?
 
 ## Output
 
 - **Format:** Markdown (`.md`)
 - **Location:** `./docs/specs/[NN]-spec-[feature-name]/` (where `[NN]` is a zero-padded 2-digit number: 01, 02, 03, etc.)
-- **Filename:** `[NN]-tasks-[feature-name].md` (e.g., if the Spec is `01-spec-user-profile-editing.md`, save as `01-tasks-user-profile-editing.md`)
+- **Task Filename:** `[NN]-tasks-[feature-name].md`
+- **Audit Filename:** `[NN]-audit-[feature-name].md`
 
 ## Process
 
 ### Phase 1: Analysis and Planning (Internal)
 
-1. **Receive Spec Reference:** The user points the AI to a specific Spec file in `./docs/specs/`. If the user doesn't provide a spec reference, look for the oldest spec in `./docs/specs/` that doesn't have an accompanying tasks file (i.e., no `[NN]-tasks-[feature-name].md` file in the same directory).
-2. **Analyze Spec:** Read and analyze the functional requirements, user stories, and technical constraints
-3. **Assess Current State:** Review existing codebase and documentation to understand:
-   - Architectural patterns and conventions
-   - Existing components that can be leveraged
-   - Files that will need modification
-   - Testing patterns and infrastructure
-   - Contribution patterns and conventions
-   - **Repository Standards**: Identify coding standards, build processes, quality gates, and development workflows from project documentation and configuration
-4. **Define Demoable Units:** Identify thin, end-to-end vertical slices. Each parent task must be demonstrable.
-5. **Evaluate Scope:** Ensure tasks are appropriately sized (not too large, not too small)
+1. **Receive Spec Reference:** The user points to a spec file. If no spec reference is provided, auto-select one spec using this priority:
+   - oldest spec missing `[NN]-tasks-[feature-name].md`
+   - else oldest spec missing `[NN]-audit-[feature-name].md`
+   - else oldest spec whose audit status is not PASS (for example: `Overall Status: FAIL` or `Required Gate Failures > 0`)
+   - else oldest spec with a stale audit (task/spec artifacts changed after audit creation or audit report is missing required sections)
+   - if none match, ask the user which spec to process
+2. **Analyze Spec:** Read functional requirements, user stories, non-goals, open questions, and technical considerations.
+3. **Assess Current State:** Review architecture, conventions, testing patterns, contribution patterns, and repository standards from project docs and configuration.
+4. **Define Demoable Units:** Identify thin, demonstrable vertical slices.
+5. **Evaluate Scope:** Ensure tasks are appropriately sized.
 
 ### Phase 2: Parent Task Generation
 
-1. **Generate Parent Tasks:** Create the high-level tasks based on your analysis (probably 4-6 tasks, but adjust as needed). Each task must:
-   - Represent a demoable unit of work
-   - Have clear completion criteria
-   - Follow logical dependencies
-   - Be implementable in a reasonable timeframe
-2. **Save Initial Task List:** Save the parent tasks to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` before proceeding
-3. **Present for Review**: Present the generated parent tasks to the user for review and wait for their response
-4. **Wait for Confirmation**: Pause and wait for user to respond with "Generate sub tasks"
+1. Generate parent tasks (typically 4-6, adjust by complexity). Each task must be demoable and sequenced logically.
+2. Save initial task list to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`.
+3. Present parent tasks to the user and wait for review.
+4. Stop and wait for explicit confirmation: `Generate sub tasks`.
 
 ### Phase 3: Sub-Task Generation
 
-Wait for explicit user confirmation before generating sub-tasks. Then:
+After explicit confirmation:
 
-1. **Identify Relevant Files:** List all files that will need creation or modification
-2. **Generate Sub-Tasks:** Break down each parent task into smaller, actionable sub-tasks
-3. **Update Task List:** Update the existing `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` file with the sub-tasks and relevant files sections
+1. Identify relevant files (create/modify)
+2. Generate actionable subtasks under each parent task
+3. Update existing task file with `Relevant Files`, notes, and complete task hierarchy
+
+If a task file already exists for the selected spec, treat this as a planning-resume flow:
+
+- Do not regenerate parent tasks/subtasks unless the user explicitly asks to regenerate them.
+- Continue with baseline planning commit verification, audit, remediation approval, and re-audit loop.
+
+### Phase 4: Baseline Planning Commit (Required)
+
+After full sub-task generation is complete:
+
+1. Confirm planning artifacts exist:
+   - spec file
+   - task file
+   - question file(s), if present
+2. Stage the planning artifacts.
+3. Create a baseline commit before running the audit.
+
+**Recommended commit message:**
+
+```text
+chore(planning): baseline spec and task artifacts for [feature-name]
+```
+
+### Phase 5: Planning Audit Checkpoint (Required)
+
+Create audit report file:
+
+- `./docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`
+
+Audit must evaluate and report these checks:
+
+1. **Requirement-to-test traceability (REQUIRED):**
+   - Fail if any functional requirement has no planned test artifact mapped in tasks.
+2. **Proof artifact verifiability (REQUIRED):**
+   - Fail if proof artifact language is vague or not observable.
+3. **Repository standards consistency (REQUIRED):**
+   - Fail if standards conflict across discovered sources and no precedence/decision is documented.
+4. **Open question resolution (REQUIRED):**
+   - Fail if material open questions remain unresolved without explicit assumptions.
+5. **Regression-risk blind spots (FLAG):**
+   - Flag if planned validation only covers happy-path behavior where regression risk exists.
+6. **Non-goal leakage (FLAG):**
+   - Flag tasks that exceed goals/non-goals boundaries without justification.
+7. **Context-aware alignment confidence (FLAG):**
+   - Compare against related specs and higher-level plans (for example PRDs/roadmaps) and include confidence (`low`, `med`, `high`) for each alignment finding.
+
+### Phase 6: Human Review Checkpoint (Required)
+
+After generating the audit report:
+
+1. Present audit findings to the user (REQUIRED failures first, then FLAG findings).
+2. Present a remediation plan with minimal, actionable items.
+3. Wait for explicit user approval before making remediation edits.
+
+**Remediation item format (mandatory):**
+
+- Exact missing item
+- Exact file section to edit
+- Exact acceptance condition
+
+### Phase 7: Remediation Execution and Re-Audit
+
+After explicit user approval:
+
+1. Apply approved remediation edits to planning artifacts.
+2. Commit remediation changes.
+3. Re-run the full audit and update the audit report.
+4. If REQUIRED gates still fail, return to Phase 6.
+5. Only proceed when all REQUIRED gates pass.
 
 ## Phase 2 Output Format (Parent Tasks Only)
 
-When generating parent tasks in Phase 2, use this hierarchical structure with Tasks section marked "TBD":
+When generating parent tasks in Phase 2, use this structure and keep each `Tasks` subsection as `TBD`:
 
 ```markdown
 ## Tasks
@@ -162,50 +251,23 @@ When generating parent tasks in Phase 2, use this hierarchical structure with Ta
 #### 1.0 Tasks
 
 TBD
-
-### [ ] 2.0 Parent Task Title
-
-#### 2.0 Proof Artifact(s)
-
-- Screenshot: User flow showing Z with persisted state demonstrates feature persistence
-- Test: `UserFlow.test.ts` passes demonstrates state management works
-
-#### 2.0 Tasks
-
-TBD
-
-### [ ] 3.0 Parent Task Title
-
-#### 3.0 Proof Artifact(s)
-
-- CLI: `config get ...` returns expected value demonstrates configuration is verifiable
-- Log: Configuration loaded message demonstrates system initialization
-- Diff: Configuration file changes demonstrates setup completion
-
-#### 3.0 Tasks
-
-TBD
 ```
 
-## Phase 3 Output Format (Complete with Sub-Tasks)
+## Phase 3 Output Format (Complete Task List)
 
-After user confirmation in Phase 3, update the file with this complete structure:
+After user confirmation in Phase 3, update the task file with complete parent tasks, subtasks, and relevant files using this structure:
 
 ```markdown
 ## Relevant Files
 
-- `path/to/potential/file1.ts` - Brief description of why this file is relevant (e.g., Contains the main component for this feature).
-- `path/to/file1.test.ts` - Unit tests for `file1.ts`.
-- `path/to/another/file.tsx` - Brief description (e.g., API route handler for data submission).
-- `path/to/another/file.test.tsx` - Unit tests for `another/file.tsx`.
-- `lib/utils/helpers.ts` - Brief description (e.g., Utility functions needed for calculations).
-- `lib/utils/helpers.test.ts` - Unit tests for `helpers.ts`.
+- `path/to/file1.ts` - Brief description
+- `path/to/file1.test.ts` - Unit tests for `file1.ts`
 
 ### Notes
 
-- Unit tests should typically be placed alongside the code files they are testing (e.g., `MyComponent.tsx` and `MyComponent.test.tsx` in the same directory).
-- Use the repository's established testing command and patterns (e.g., `npx jest [optional/path/to/test/file]`, `pytest [path]`, `cargo test`, etc.).
-- Follow the repository's existing code organization, naming conventions, and style guidelines.
+- Unit tests should typically be placed alongside tested files.
+- Use the repository's established testing command and patterns.
+- Follow repository organization, naming conventions, and style guidelines.
 - Adhere to identified quality gates and pre-commit hooks.
 
 ## Tasks
@@ -214,91 +276,125 @@ After user confirmation in Phase 3, update the file with this complete structure
 
 #### 1.0 Proof Artifact(s)
 
-- Screenshot: `/path` page showing completed X flow demonstrates end-to-end functionality
-- URL: https://... demonstrates feature is accessible
-- CLI: `command --flag` returns expected output demonstrates feature works
 - Test: `MyFeature.test.ts` passes demonstrates requirement implementation
 
 #### 1.0 Tasks
 
-- [ ] 1.1 [Sub-task description 1.1]
-- [ ] 1.2 [Sub-task description 1.2]
+- [ ] 1.1 [Sub-task description]
+- [ ] 1.2 [Sub-task description]
+```
 
-### [ ] 2.0 Parent Task Title
+## Audit Report Format (Phase 5 and Later)
 
-#### 2.0 Proof Artifact(s)
+Use this structure in `[NN]-audit-[feature-name].md`:
 
-- Screenshot: User flow showing Z with persisted state demonstrates feature persistence
-- Test: `UserFlow.test.ts` passes demonstrates state management works
+```markdown
+# [NN]-audit-[feature-name].md
 
-#### 2.0 Tasks
+## Executive Summary
 
-- [ ] 2.1 [Sub-task description 2.1]
-- [ ] 2.2 [Sub-task description 2.2]
+- Overall Status: PASS/FAIL
+- Required Gate Failures: [count]
+- Flagged Risks: [count]
 
-### [ ] 3.0 Parent Task Title
+## Gate Results
 
-#### 3.0 Proof Artifact(s)
+| Gate | Type | Status | Evidence |
+| --- | --- | --- | --- |
+| Requirement-to-test traceability | REQUIRED | FAIL | `...` |
 
-- CLI: `config get ...` returns expected value demonstrates configuration is verifiable
-- Log: Configuration loaded message demonstrates system initialization
-- Diff: Configuration file changes demonstrates setup completion
+## Traceability Matrix
 
-#### 3.0 Tasks
+| Functional Requirement | Task IDs | Planned Test Artifact | Proof Artifact |
+| --- | --- | --- | --- |
+| FR-1 | 1.0, 1.2 | `tests/...` | `CLI: ...` |
 
-- [ ] 3.1 [Sub-task description 3.1]
-- [ ] 3.2 [Sub-task description 3.2]
+## Standards Analysis
+
+- Sources reviewed
+- Conflicts found
+- Documented precedence/decision status
+
+## Context-Aware Alignment
+
+- Artifact compared: [path]
+- Finding: [summary]
+- Confidence: low|med|high
+
+## Findings
+
+### REQUIRED Failures
+
+1. [Issue]
+   - Missing item:
+   - File section to edit:
+   - Acceptance condition:
+
+### FLAG Findings
+
+1. [Issue]
+   - Risk:
+   - Suggested remediation:
+
+## User-Approved Remediation Plan
+
+- Pending approval | Approved | Completed
+
+## Re-Audit History
+
+- Run 1: [summary]
+- Run 2: [summary]
 ```
 
 ## Interaction Model
 
-**Critical:** This is a two-phase process that requires explicit user confirmation:
+This is now a **multi-checkpoint planning flow** with explicit user approvals:
 
-1. **Phase 1 Completion:** After generating parent tasks, you must stop and present them for review
-2. **Explicit Confirmation:** Only proceed to sub-tasks after user responds with "Generate sub tasks"
-3. **No Auto-progression:** Never automatically proceed to sub-tasks or implementation
+1. Parent task review checkpoint (before subtasks)
+2. Human remediation approval checkpoint (after audit findings)
+3. Re-audit loop checkpoint (if REQUIRED gates fail)
 
-**Example interaction:**
-> "I have analyzed the spec and generated [X] parent tasks that represent demoable units of work. Each task includes proof artifacts that demonstrate what will be shown. Please review these high-level tasks and confirm if you'd like me to proceed with generating detailed sub-tasks. Respond with 'Generate sub tasks' to continue."
+No remediation edits may be made before explicit user approval.
 
 ## Target Audience
 
-Write tasks and sub-tasks for a **junior developer** who:
+Write tasks and subtasks for a **junior developer** who:
 
-- Understands the programming language and framework
-- Is familiar with the existing codebase structure
+- Understands the language/framework
+- Is familiar with repository structure
 - Needs clear, actionable steps without ambiguity
-- Will be implementing tasks independently
 - Relies on proof artifacts to verify completion
-- Must follow established repository patterns and conventions
+- Must follow identified repository standards and conventions
 
 ## Quality Checklist
 
-Before finalizing your task list, verify:
+Before handing off to implementation, verify:
 
-- [ ] Each parent task is demoable and has clear completion criteria
-- [ ] Proof Artifacts are specific and demonstrate clear functionality
-- [ ] Proof Artifacts are appropriate for each task
-- [ ] Tasks are appropriately scoped (not too large/small)
-- [ ] Dependencies are logical and sequential
+- [ ] Parent tasks are demoable and appropriately scoped
 - [ ] Sub-tasks are actionable and unambiguous
 - [ ] Relevant files are comprehensive and accurate
-- [ ] Format follows the exact structure specified above
-- [ ] Repository standards and patterns are identified and incorporated
-- [ ] Implementation will follow established coding conventions and workflows
+- [ ] Every functional requirement maps to planned test artifacts
+- [ ] Proof artifacts are specific, observable, and verifiable
+- [ ] Standards conflicts are resolved or documented
+- [ ] Material open questions are resolved or explicit assumptions are documented
+- [ ] Context-aware findings include confidence labels
+- [ ] Baseline planning commit exists
+- [ ] Audit report exists and is current
+- [ ] REQUIRED gates are passing
+- [ ] Any remediation edits were explicitly user-approved
 
 ## What Comes Next
 
-Once this task list is complete and approved, instruct the user to run `/SDD-3-manage-tasks` to begin implementation. This maintains the workflow's progression from idea → spec → tasks → implementation → validation.
+Only after all REQUIRED audit gates pass, instruct the user to run `/SDD-3-manage-tasks`.
 
 ## Final Instructions
 
-1. Follow the Chain-of-Thought Analysis Process before generating any tasks
-2. Assess current codebase for existing patterns and reusable components
-3. Generate high-level tasks that represent demoable units of work (adjust count based on spec complexity) and save them to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
-4. **CRITICAL**: Stop after generating parent tasks and wait for "Generate sub tasks" confirmation before proceeding.
-5. Ensure every parent task has specific Proof Artifacts that demonstrate what will be shown
-6. Identify all relevant files for creation/modification
-7. Review with user and refine until satisfied
-8. Guide user to the next workflow step (`/SDD-3-manage-tasks`)
-9. Stop working once user confirms task list is complete
+1. Follow the analysis process before generating tasks.
+2. Stop after parent tasks and wait for `Generate sub tasks`.
+3. Generate full task list with relevant files and proof artifacts.
+4. Create baseline planning commit before audit.
+5. Generate audit report with REQUIRED and FLAG findings.
+6. Present findings and remediation plan; get explicit approval before edits.
+7. Apply approved remediation and commit changes.
+8. Re-run full audit until REQUIRED gates pass.
+9. Hand off to `/SDD-3-manage-tasks` only when audit is passing.

--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -106,6 +106,20 @@ Proof artifacts provide evidence of task completion and are essential for the up
 
 **Security Note**: When planning proof artifacts, remember that they will be committed to the repository. Artifacts should use placeholder values for API keys, tokens, and other sensitive data rather than real credentials.
 
+## Evidence Quality Bar (Required)
+
+For each parent task, proof artifacts must satisfy all four checks:
+
+1. **Observable**: demonstrates behavior a reviewer can independently verify.
+2. **Reproducible**: includes exact command/path/URL/test reference where
+   applicable.
+3. **Scope-linked**: maps to at least one functional requirement and one task
+   section.
+4. **Sanitized**: contains no secrets, credentials, or private identifiers.
+
+Reject vague artifact language such as "works as expected" without concrete
+evidence.
+
 ## Chain-of-Thought Analysis Process
 
 Before generating any tasks, you must follow this reasoning process:

--- a/prompts/SDD-3-manage-tasks.md
+++ b/prompts/SDD-3-manage-tasks.md
@@ -133,6 +133,12 @@ When all sub-tasks are `[x]`, complete these steps IN ORDER:
    - **Execute commands immediately**: Capture command output directly in the markdown file
    - **Verify creation**: Confirm the markdown file exists and contains all required evidence
 [ ] **Verify Proof Artifacts**: Confirm all proof artifacts demonstrate required functionality
+[ ] **Artifact Sufficiency Gate**: Verify proof quality before commit
+   - Proof file exists at required path
+   - Evidence covers all listed artifacts for the parent task
+   - Evidence demonstrates functionality and quality checks (tests/lint/typecheck or repository-equivalent gates)
+   - Environment-specific values are sanitized
+   - Evidence is concise and reviewer-usable
 [ ] **Stage Changes**: `git add .`
 [ ] **Create Commit**: Use repository's commit format and conventions
 

--- a/prompts/SDD-3-manage-tasks.md
+++ b/prompts/SDD-3-manage-tasks.md
@@ -129,7 +129,7 @@ When all sub-tasks are `[x]`, complete these steps IN ORDER:
 [ ] **Create Proof Artifacts**: Create a single markdown file with all evidence for the task in `./docs/specs/[NN]-spec-[feature-name]/[NN]-proofs/` (where `[NN]` is a two-digit, zero-padded number, e.g., `01`, `02`, etc.)
    - **File naming**: `[spec-number]-task-[task-number]-proofs.md` (e.g., `03-task-01-proofs.md`)
    - **Include all evidence**: CLI output, test results, screenshots, configuration examples
-   - **Format**: Use markdown code blocks with clear section headers
+   - **Format**: Use reviewer-friendly markdown with a descriptive title, summary-first sections, and code blocks only after context is established
    - **Execute commands immediately**: Capture command output directly in the markdown file
    - **Verify creation**: Confirm the markdown file exists and contains all required evidence
 [ ] **Verify Proof Artifacts**: Confirm all proof artifacts demonstrate required functionality
@@ -217,6 +217,15 @@ Each parent task must include artifacts that:
 - **Enable validation** (provide evidence for `/SDD-4-validate-spec-implementation`)
 - **Support troubleshooting** (logs, error messages, configuration states)
 
+Proof artifacts must be optimized for fast human review, not just raw evidence storage.
+
+- Lead with what the task proves before showing raw output.
+- Use descriptive headings that name the task outcome, not just the proof filename.
+- Explain why each artifact matters before presenting commands, logs, or screenshots.
+- Keep raw evidence intact, but front-load interpretation so a reviewer can understand the result quickly.
+- For screenshots, always show the artifact path above the image and embed the image inline in the proof file.
+- If output is long, summarize the important result first and then include the most relevant excerpt or reference to the full artifact path.
+
 ### Security Warning
 
 **CRITICAL**: Proof artifacts will be committed to the repository. Never include sensitive data:
@@ -236,22 +245,116 @@ For each parent task completion:
 [ ] **Directory Ready**: `./docs/specs/[NN]-spec-[feature-name]/[NN]-proofs/` exists
 [ ] **Review Task Requirements**: Check what proof artifacts the task specifically requires
 [ ] **Create Single Proof File**: Create `[spec-number]-task-[task-number]-proofs.md`
-[ ] **Include All Evidence in One File**:
-   - ## CLI Output section with command results
-   - ## Test Results section with test output
-   - ## Screenshots section with image references
-   - ## Configuration section with config examples
-   - ## Verification section showing proof artifacts demonstrate required functionality
+[ ] **Use A Reviewable Structure**:
+   - `# Task [TT] Proofs - [descriptive task outcome]`
+   - `## Task Summary` explaining what was built and why this task matters
+   - `## What This Task Proves` mapping the task to the key behaviors now working
+   - `## Evidence Summary` giving a short reviewer-oriented overview before raw artifacts
+[ ] **Document Each Artifact With Context Before Evidence**:
+   - `## Artifact: [descriptive name]`
+   - `**What it proves:** [specific behavior or requirement validated]`
+   - `**Why it matters:** [why a reviewer should care about this artifact]`
+   - `**Command**` or `**Artifact path**`
+   - `**Result summary:** [1-3 sentence interpretation of the evidence]`
+   - Raw evidence block or inline image
+[ ] **Present Screenshots For Fast Review**:
+   - Show the screenshot file path in its own line above the image
+   - Embed every screenshot inline using standard markdown image syntax
+   - Use alt text that describes the visible behavior being proven
+[ ] **Keep Verification Context Near The Top**:
+   - Do not rely on a bottom-only `Verification` section to explain relevance
+   - Place interpretation before the raw command output, logs, or screenshots
+[ ] **End With A Short Reviewer Conclusion**:
+   - State the final conclusion the reviewer should draw from the combined evidence
 [ ] **Format with Markdown**: Use code blocks, headers, and clear organization
 [ ] **Verify File Content**: Ensure the markdown file contains all required evidence
 [ ] **Security Check**: Scan proof file for API keys, tokens, passwords, or other sensitive data and replace with placeholders
 
 **SIMPLE VERIFICATION**: One file per task, all evidence included
-**CONTENT VERIFICATION**: Check the markdown file contains required sections
+**CONTENT VERIFICATION**: Check the markdown file contains both context-setting summary sections and raw evidence
 **VERIFICATION**: Ensure proof artifact file demonstrates all required functionality
 **SECURITY VERIFICATION**: Confirm no real credentials or sensitive data are present
 
 **The single markdown proof file must be created BEFORE the parent task commit**
+```
+
+### Recommended Proof File Shape
+
+Use this structure unless the task requires a clearly better equivalent.
+
+```markdown
+# Task 02 Proofs - Metabase bootstrap and first-run setup
+
+## Task Summary
+
+This task proves the bootstrap flow can start Metabase, wait for readiness, complete first-run admin setup, and expose a usable local instance without manual setup steps.
+
+## What This Task Proves
+
+- The bootstrap command starts a Metabase container and waits until it becomes reachable.
+- The first-run setup flow succeeds and returns a usable local Metabase URL.
+- The bootstrap orchestration is covered by automated tests for both success and failure paths.
+
+## Evidence Summary
+
+- A successful bootstrap CLI run returns `status: ok` and a local Metabase URL.
+- The health endpoint returns `{"status":"ok"}`, confirming the container is reachable after bootstrap.
+- The task-specific pytest suite passes, confirming the orchestration logic is covered automatically.
+
+## Artifact: Successful bootstrap CLI run
+
+**What it proves:** The bootstrap flow can start Metabase, complete readiness polling, and return a usable handoff payload.
+
+**Why it matters:** This is the main end-to-end proof that the task's core runtime behavior works.
+
+**Command:**
+
+~~~bash
+python3 ...
+~~~
+
+**Artifact path:** `artifacts/.../cli.txt`
+
+**Result summary:** The command returned `status: ok`, exposed a local Metabase URL, and included sanitized handoff details plus cleanup commands.
+
+~~~json
+{ ... }
+~~~
+
+## Artifact: Metabase health endpoint
+
+**What it proves:** The started Metabase instance is reachable after bootstrap.
+
+**Why it matters:** A successful bootstrap is not enough if the service is not actually available to the user.
+
+**Command:**
+
+~~~bash
+curl -s http://127.0.0.1:3000/api/health
+~~~
+
+**Result summary:** The endpoint returned `{"status":"ok"}`, confirming the local instance is healthy.
+
+~~~json
+{"status":"ok"}
+~~~
+
+## Artifact: Database list screenshot
+
+**What it proves:** The configured database appears in the Metabase UI after bootstrap.
+
+**Why it matters:** This confirms the feature is visible in the actual user-facing interface, not just in backend or CLI output.
+
+**Artifact path:** `artifacts/.../database-list.png`
+
+**Result summary:** The screenshot shows the connected database in the Metabase database list, confirming the setup is visible to a human reviewer.
+
+![Database list showing connected Metabase source](artifacts/.../database-list.png)
+
+## Reviewer Conclusion
+
+These artifacts show the task's runtime behavior works end-to-end: Metabase starts successfully, becomes reachable, and is backed by automated orchestration tests.
+
 ```
 
 ## Git Workflow Protocol

--- a/prompts/SDD-3-manage-tasks.md
+++ b/prompts/SDD-3-manage-tasks.md
@@ -39,6 +39,7 @@ This implementation phase serves as the **execution engine** for the entire SDD 
 - **Parent tasks** become implementation checkpoints and commit boundaries
 - **Proof artifacts** guide implementation verification and become the evidence source for `/SDD-4-validate-spec-implementation`
 - **Task boundaries** determine git commit points and progress markers
+- **Planning audit report** from `/SDD-2-generate-task-list-from-spec` confirms planning quality gates passed before implementation starts
 
 **What Breaks the Chain:**
 
@@ -88,6 +89,10 @@ For each parent task, follow this structured workflow with built-in verification
 ## PRE-WORK CHECKLIST (Complete before starting any sub-task)
 
 [ ] Locate task file: `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
+[ ] Locate audit file: `./docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`
+[ ] Verify audit report exists and is current for this spec
+[ ] Verify all REQUIRED planning audit gates are PASS
+[ ] If REQUIRED gates are not PASS, stop and return to `/SDD-2-generate-task-list-from-spec`
 [ ] Read current task status and identify next sub-task
 [ ] Verify checkpoint mode preference with user
 [ ] Review proof artifacts required for current parent task
@@ -298,11 +303,12 @@ The validation phase will use your proof artifacts as evidence to verify that th
 ## Instructions
 
 1. **Locate Task File**: Find the task list in `./docs/specs/` directory
-2. **Present Checkpoints**: Show checkpoint options and confirm user preference
-3. **Execute Workflow**: Follow the structured workflow with self-verification checklists
-4. **Validate Progress**: Use verification checkpoints before proceeding
-5. **Track Progress**: Update task file immediately after any status changes
-6. **Complete or Continue**:
+2. **Verify Planning Audit Status**: Confirm audit report exists and all REQUIRED gates passed before any implementation work
+3. **Present Checkpoints**: Show checkpoint options and confirm user preference
+4. **Execute Workflow**: Follow the structured workflow with self-verification checklists
+5. **Validate Progress**: Use verification checkpoints before proceeding
+6. **Track Progress**: Update task file immediately after any status changes
+7. **Complete or Continue**:
    - If tasks remain, proceed to next parent task
    - If all complete, instruct user to proceed to validation
 

--- a/prompts/SDD-4-validate-spec-implementation.md
+++ b/prompts/SDD-4-validate-spec-implementation.md
@@ -109,7 +109,7 @@ Map score to severity: 0→CRITICAL, 1→HIGH, 2→MEDIUM, 3→OK.
 - **R2 Proof Artifacts:** Each Proof Artifact is accessible and demonstrates the required functionality.
 - **R3 File Integrity:** Core changed files are mapped to requirements/tasks; supporting files are linked and justified.
 - **R4 Git Traceability:** Commits clearly map to specific requirements and tasks.
-- **R5 Evidence Quality:** Evidence includes proof artifact test results and file existence checks.
+- **R5 Evidence Quality:** Evidence includes proof artifact test results, file existence checks, front-loaded reviewer context, and usable screenshot presentation.
 - **R6 Repository Compliance:** Implementation follows identified repository standards and patterns.
 
 ## Validation Process (step-by-step chain-of-thought)
@@ -161,6 +161,7 @@ For each Functional Requirement, Demoable Unit, and Repository Standard:
    - Verify proof artifact files exist (from task list)
    - Test that each Proof Artifact (URLs, CLI commands, test references) demonstrates what it claims
    - Verify file existence for "Relevant Files" listed in task list
+   - Check that proof docs explain what each artifact proves before presenting raw evidence
    - Check repository pattern compliance (via proof artifacts, file checks, and commit log analysis)
 3) Record **evidence** (proof artifact test results, file existence checks, commit references).
 4) Mark each item **Verified**, **Failed**, or **Unknown**.
@@ -174,11 +175,14 @@ For each Functional Requirement, Demoable Unit, and Repository Standard:
    - Out-of-scope core files without linkage are blockers
 
 2) **Proof Artifact Verification**
-   - URLs are accessible and return expected content
-   - CLI commands execute successfully with expected output
-   - Test references exist and can be executed
-   - Screenshots/demos show required functionality
-   - **Security Check**: Proof artifacts contain no real API keys, tokens, passwords, or sensitive data
+    - URLs are accessible and return expected content
+    - CLI commands execute successfully with expected output
+    - Test references exist and can be executed
+    - Screenshots/demos show required functionality
+    - Proof docs use descriptive titles and front-load task context before raw evidence
+    - Screenshot artifacts show the file path and embed the image inline in the proof doc
+    - Raw evidence is preceded by a short explanation of what it proves and why it matters
+    - **Security Check**: Proof artifacts contain no real API keys, tokens, passwords, or sensitive data
 
 3) **Requirement Coverage**
    - Proof Artifacts exist for each Functional Requirement
@@ -262,6 +266,7 @@ For each issue, provide:
 | HIGH | Proof Artifact URL returns 404. `task-list.md#L45` references `https://example.com/demo`. Evidence: `curl -I https://example.com/demo` → "HTTP/1.1 404 Not Found" | Functionality cannot be verified | Update URL in task list or deploy missing endpoint |
 | CRITICAL | Unmapped out-of-scope core file. `src/auth.ts` created with no task/FR linkage. Evidence: `git log --name-only` shows file created; no mapping in tasks/report/commit notes | Implementation scope creep | Add explicit FR/task mapping and rationale, or remove unrelated core change |
 | MEDIUM | Supporting-file linkage missing. `docs/specs/.../proofs/*.md` changed but no explicit linkage to core task in notes. Evidence: changed-file list vs task metadata | Traceability gap, verification still possible | Add linkage note in task list or validation report appendix |
+| MEDIUM | Proof artifact is hard to review quickly. `docs/specs/.../01-proofs/01-task-03-proofs.md` uses a filename-only title, lists screenshot paths without inline images, and explains relevance only at the bottom. Evidence: proof doc structure review | Human verification is slowed and context is easy to miss | Rewrite the proof doc with a descriptive title, summary-first sections, inline screenshots, and per-artifact interpretation before raw evidence |
 
 **Note:** Do not report issues that are already clearly marked in the Coverage Matrix unless additional context is needed. Focus on actionable problems that need resolution.
 

--- a/prompts/SDD-4-validate-spec-implementation.md
+++ b/prompts/SDD-4-validate-spec-implementation.md
@@ -80,12 +80,26 @@ If no spec is provided, follow this exact sequence:
 - **GATE A (blocker):** Any **CRITICAL** or **HIGH** issue → **FAIL**.
 - **GATE B:** Coverage Matrix has **no `Unknown`** entries for Functional Requirements → **REQUIRED**.
 - **GATE C:** All Proof Artifacts are accessible and functional → **REQUIRED**.
-- **GATE D (tiered file integrity):** classify changed files and evaluate by risk:
+- **GATE D (tiered file integrity):** classify changed files and evaluate by risk (see **Core vs Supporting File Linkage Clarification** below):
   - **D1 (blocker):** Any **unmapped out-of-scope source code change** (`src/`, `app/`, `lib/`, runtime config, infra code) with no requirement/task linkage → **FAIL**.
   - **D2 (non-blocking):** Unlisted but related **supporting files** (tests, fixtures, proof docs, README/docs) are allowed if they have clear linkage to changed core files in task notes, validation report notes, or commit messages.
   - **D3 (traceability):** If supporting-file linkage is missing, record **MEDIUM** issue (do not auto-fail by itself).
 - **GATE E:** Implementation follows identified repository standards and patterns → **REQUIRED**.
 - **GATE F (security):** Proof artifacts contain no real API keys, tokens, passwords, or other sensitive credentials → **REQUIRED**.
+
+## Core vs Supporting File Linkage Clarification
+
+To keep validation portable across repositories:
+
+- Treat source/runtime-impacting changes as **core** and require explicit
+  requirement/task linkage.
+- Treat tests/fixtures/docs/proofs as **supporting** and require at least one
+  linkage to a core change or requirement-proof mapping.
+- Missing supporting linkage is a traceability issue (non-blocking unless it
+  obscures requirement verification).
+- Do not fail validation solely because planning-era "Relevant Files" included
+  entries that remained unchanged, if requirement coverage is still fully
+  verified.
 
 ## Evaluation Rubric (score each 0–3 to guide severity)
 

--- a/prompts/SDD-4-validate-spec-implementation.md
+++ b/prompts/SDD-4-validate-spec-implementation.md
@@ -80,7 +80,10 @@ If no spec is provided, follow this exact sequence:
 - **GATE A (blocker):** Any **CRITICAL** or **HIGH** issue → **FAIL**.
 - **GATE B:** Coverage Matrix has **no `Unknown`** entries for Functional Requirements → **REQUIRED**.
 - **GATE C:** All Proof Artifacts are accessible and functional → **REQUIRED**.
-- **GATE D:** All changed files are either in "Relevant Files" list OR explicitly justified in git commit messages → **REQUIRED**.
+- **GATE D (tiered file integrity):** classify changed files and evaluate by risk:
+  - **D1 (blocker):** Any **unmapped out-of-scope source code change** (`src/`, `app/`, `lib/`, runtime config, infra code) with no requirement/task linkage → **FAIL**.
+  - **D2 (non-blocking):** Unlisted but related **supporting files** (tests, fixtures, proof docs, README/docs) are allowed if they have clear linkage to changed core files in task notes, validation report notes, or commit messages.
+  - **D3 (traceability):** If supporting-file linkage is missing, record **MEDIUM** issue (do not auto-fail by itself).
 - **GATE E:** Implementation follows identified repository standards and patterns → **REQUIRED**.
 - **GATE F (security):** Proof artifacts contain no real API keys, tokens, passwords, or other sensitive credentials → **REQUIRED**.
 
@@ -90,7 +93,7 @@ Map score to severity: 0→CRITICAL, 1→HIGH, 2→MEDIUM, 3→OK.
 
 - **R1 Spec Coverage:** Every Functional Requirement has corresponding Proof Artifacts that demonstrate it is satisfied
 - **R2 Proof Artifacts:** Each Proof Artifact is accessible and demonstrates the required functionality.
-- **R3 File Integrity:** All changed files are listed in "Relevant Files" and vice versa.
+- **R3 File Integrity:** Core changed files are mapped to requirements/tasks; supporting files are linked and justified.
 - **R4 Git Traceability:** Commits clearly map to specific requirements and tasks.
 - **R5 Evidence Quality:** Evidence includes proof artifact test results and file existence checks.
 - **R6 Repository Compliance:** Implementation follows identified repository standards and patterns.
@@ -121,6 +124,20 @@ Map score to severity: 0→CRITICAL, 1→HIGH, 2→MEDIUM, 3→OK.
 - **Also**, parse Repository Standards from the Spec
 - **Finally**, parse all Proof Artifacts from the task list
 
+### File Classification Rules (for GATE D)
+
+Classify each changed file before deciding PASS/FAIL:
+
+1. **Core implementation files** (high risk): production code, runtime config, infra code, schema/contracts that affect runtime behavior.
+2. **Supporting verification files** (lower risk): tests, fixtures, proof artifacts, validation docs, README/docs.
+3. **Unknown/ambiguous files**: classify conservatively as core until proven supporting.
+
+Validation expectation:
+
+- Core files must map to Functional Requirements/tasks.
+- Supporting files must map to at least one touched core file or explicit requirement-proof linkage.
+- Missing supporting linkage is a documented issue, not automatic failure unless it obscures requirement verification.
+
 ### Step 4 — Evidence Verification
 
 For each Functional Requirement, Demoable Unit, and Repository Standard:
@@ -137,9 +154,10 @@ For each Functional Requirement, Demoable Unit, and Repository Standard:
 ## Detailed Checks
 
 1) **File Integrity**
-   - All changed files appear in "Relevant Files" section OR are justified in commit messages
-   - All "Relevant Files" that should be changed are actually changed
-   - Files outside scope must have clear justification in git history
+   - Core changed files appear in "Relevant Files" section OR have explicit requirement/task linkage
+   - Supporting changed files may be outside "Relevant Files" if linked in task notes, validation notes, or commit messages
+   - "Relevant Files" are planning guidance; unchanged entries are acceptable when validated as not requiring modifications
+   - Out-of-scope core files without linkage are blockers
 
 2) **Proof Artifact Verification**
    - URLs are accessible and return expected content
@@ -167,7 +185,7 @@ For each Functional Requirement, Demoable Unit, and Repository Standard:
 ## Red Flags (auto CRITICAL/HIGH)
 
 - Missing or non-functional Proof Artifacts
-- Changed files not listed in "Relevant Files" without justification in commit messages
+- Unmapped out-of-scope **core/source** file changes with no requirement/task linkage
 - Functional Requirements with no proof artifacts
 - Git commits unrelated to spec implementation
 - Any `Unknown` entries in the Coverage Matrix
@@ -228,8 +246,8 @@ For each issue, provide:
 | Severity | Issue | Impact | Recommendation |
 | --- | --- | --- | --- |
 | HIGH | Proof Artifact URL returns 404. `task-list.md#L45` references `https://example.com/demo`. Evidence: `curl -I https://example.com/demo` → "HTTP/1.1 404 Not Found" | Functionality cannot be verified | Update URL in task list or deploy missing endpoint |
-| CRITICAL | Changed file not in "Relevant Files". `src/auth.ts` created but not listed in task list. Evidence: `git log --name-only` shows file created; task list only references `src/user.ts` | Implementation scope creep | Update task list to include `src/auth.ts` or revert unauthorized changes |
-| MEDIUM | Missing proof artifact for FR-2. Task list specifies test file `src/feature/x.test.ts` but file does not exist. Evidence: File check shows `src/feature/x.test.ts` missing | Requirement verification incomplete | Add test file `src/feature/x.test.ts` as specified in task list |
+| CRITICAL | Unmapped out-of-scope core file. `src/auth.ts` created with no task/FR linkage. Evidence: `git log --name-only` shows file created; no mapping in tasks/report/commit notes | Implementation scope creep | Add explicit FR/task mapping and rationale, or remove unrelated core change |
+| MEDIUM | Supporting-file linkage missing. `docs/specs/.../proofs/*.md` changed but no explicit linkage to core task in notes. Evidence: changed-file list vs task metadata | Traceability gap, verification still possible | Add linkage note in task list or validation report appendix |
 
 **Note:** Do not report issues that are already clearly marked in the Coverage Matrix unless additional context is needed. Focus on actionable problems that need resolution.
 


### PR DESCRIPTION
## Summary
This branch significantly strengthens the prompt-driven workflow across planning, spec generation, implementation evidence, and validation. The net effect is a more opinionated and reviewable SDD loop that blocks weak planning earlier, asks fewer unnecessary questions during spec generation, and produces artifacts that are easier for humans to inspect.

## What changed
### 1. Add a mandatory planning-audit checkpoint in SDD-2
- insert a required audit between task generation and implementation handoff
- require human-approved remediation before planning defects can be corrected
- allow existing spec/task work to resume through audit/remediation without regenerating the plan
- add compact Gateboard-first reporting, re-audit deltas, and a reset/restart recommendation when planning debt is too high

### 2. Make planning audit decisions more reliable
- require explicit repository-standards discovery before audit decisions are made
- add a required standards evidence table so audit conclusions are grounded in actual repo guidance files instead of inferred behavior
- add a chain-of-verification pass before handing work to SDD-3
- clarify failure handling when standards files or other planning evidence are missing
- tighten proof-artifact and requirement-to-test expectations during task planning

### 3. Improve SDD-1 spec generation and clarification behavior
- replace the old always-generate-a-questions-file behavior with a clarification sufficiency check
- allow SDD-1 to proceed directly to spec generation when the request is already clear enough
- still force a questions file when ambiguity is material, requirements would be guessed, or current best practices leave meaningful approach choices open
- require generated questions files to include recommended answers and rationale so users get guided choices instead of a flat questionnaire
- add example guidance showing the intended recommendation style

### 4. Ground specs in current external guidance, not just repo patterns
- require latest-standards research for technologies that materially affect the spec
- prefer recent official or primary-source guidance when available
- route repo-pattern-vs-modern-guidance conflicts back through the clarification flow when the right direction is unclear
- require technical considerations in the spec to incorporate relevant current best practices or call out intentional deviations

### 5. Improve task and proof artifact review UX
- change the SDD-2 `Relevant Files` section from a bullet list to a markdown table for easier scanability
- require SDD-3 proof artifacts to lead with human-readable context instead of starting with raw command output
- require descriptive proof titles, summary-first layout, per-artifact "what it proves / why it matters" framing, and short reviewer conclusions
- require screenshot paths to be shown above inline embedded images so proof docs support faster visual review
- add an example proof document shape that demonstrates the expected format

### 6. Strengthen validation semantics in SDD-4
- refine file-integrity handling so unmapped core/source drift is blocker-level, while supporting-file linkage gaps are documented without automatically failing validation
- tighten evidence-quality expectations so validation looks at proof usability, not just proof existence
- explicitly check for descriptive proof titles, front-loaded context, inline screenshot presentation, and explanation before raw evidence
- add clearer examples of non-blocking reviewability issues in validation output

### 7. Update docs to match the new workflow
- update `README.md` to describe the audit-first planning flow, conditional questions files, current-standards grounding, and generated artifact set
- extend `docs/faq.md` with planning-audit/remediation behavior so the docs tell the same story as the prompts

## Why this matters
Before this branch, the workflow was easier to move through quickly, but it also allowed weak planning handoffs, over-eager question generation, and proof artifacts that were technically present but slow for humans to validate. These changes push the workflow toward:
- better planning discipline before implementation starts
- fewer unnecessary clarification loops
- more grounded technical direction for modern stacks
- faster human review of both plans and proof artifacts
- clearer validation outcomes when evidence quality is weak

## Files changed
- `README.md`
- `docs/faq.md`
- `prompts/SDD-1-generate-spec.md`
- `prompts/SDD-2-generate-task-list-from-spec.md`
- `prompts/SDD-3-manage-tasks.md`
- `prompts/SDD-4-validate-spec-implementation.md`

## Validation
This is a prompt/docs-only branch. Validation focused on prompt/doc linting and consistency checks.

- `pre-commit run --files "prompts/SDD-1-generate-spec.md" "README.md"`
- `pre-commit run --files "prompts/SDD-3-manage-tasks.md" "prompts/SDD-4-validate-spec-implementation.md"`
- `pre-commit run --files "prompts/SDD-2-generate-task-list-from-spec.md"`

## Reviewer notes
- this PR intentionally spans multiple prompts because the changes are workflow-coupled: planning audit behavior affects implementation handoff, proof artifacts affect validation, and spec clarification changes affect downstream planning quality
- there are no application/runtime code changes in this branch; the impact is entirely in workflow behavior and generated markdown artifacts