### PR TITLE
feat: add SDD agent skill install option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install test and lint dependencies
+        run: pip install pre-commit pytest
+
+      - name: Run skill tests
+        run: python -m pytest -q
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,15 @@ default_install_hook_types: [pre-commit, pre-push, commit-msg]
 default_stages: [pre-commit]
 
 repos:
+  - repo: local
+    hooks:
+      - id: pytest-skill-tests
+        name: run deterministic skill tests
+        entry: python -m pytest -q
+        language: system
+        pass_filenames: false
+        always_run: true
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,10 @@ pre-commit run cspell --all-files
 Before submitting a PR, follow [`docs/TESTING.md`](docs/TESTING.md):
 
 ```bash
-python -m pytest -q
 pre-commit run --all-files
 ```
 
-The pytest suite verifies deterministic skill behavior and static skill contract checks. The pre-commit gate checks YAML syntax, fixes Markdown formatting issues, spell-checks public-facing documentation and workflow prompts, and validates commit message format on commit.
+The pre-commit gate runs the deterministic pytest suite, checks YAML syntax, fixes Markdown formatting issues, spell-checks public-facing documentation and workflow prompts, scans committed content for secrets, and validates commit message format on commit. CI also runs the skill tests as a dedicated step before the full pre-commit gate.
 
 ## Branching and Commit Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,19 +100,14 @@ pre-commit run cspell --all-files
 
 ## Testing
 
-Before submitting a PR, run:
+Before submitting a PR, follow [`docs/TESTING.md`](docs/TESTING.md):
 
 ```bash
-# Run all pre-commit checks
+python -m pytest -q
 pre-commit run --all-files
 ```
 
-This will:
-
-- Check YAML syntax
-- Fix Markdown formatting issues
-- Spell-check public-facing documentation and workflow prompts
-- Validate commit message format (on commit)
+The pytest suite verifies deterministic skill behavior and static skill contract checks. The pre-commit gate checks YAML syntax, fixes Markdown formatting issues, spell-checks public-facing documentation and workflow prompts, and validates commit message format on commit.
 
 ## Branching and Commit Conventions
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Overview
 
-This repository provides **structured prompts** (Markdown files) that guide AI assistants through a complete software development workflow:
+This repository provides **structured prompts** and an alternate **agent skill** that guide AI assistants through a complete software development workflow:
 
 - **Define intent**: generate a reviewed spec with clear demo criteria
 - **Plan**: break work into demoable tasks and subtasks, then run a planning audit gate
@@ -86,16 +86,48 @@ uvx --from git+https://github.com/liatrio-labs/slash-command-manager `
 
 <img max-width="500" alt="Example of slash commands installed in Windsurf" src="docs/assets/images/slash-command-example-windsurf.png" />
 
-#### Option B: Manual Copy-Paste (No Installation)
+#### Option B: Install as Agent Skill
+
+Use this option for AI assistants that support skill folders or skill-native workflows, especially environments where custom prompts or slash-command prompt packs are unavailable or deprecated.
+
+Install the SDD skill using the [`skills.sh`](https://skills.sh) CLI:
+
+```bash
+# List available skills in this repository without installing
+npx skills add liatrio-labs/spec-driven-workflow --list
+
+# Install the SDD skill
+npx skills add liatrio-labs/spec-driven-workflow --skill sdd
+
+# Install the SDD skill non-interactively
+npx -y skills add liatrio-labs/spec-driven-workflow --skill sdd
+
+# Install to specific agents
+npx skills add liatrio-labs/spec-driven-workflow --skill sdd -a cursor -a codex
+
+# Install globally instead of project scope
+npx skills add liatrio-labs/spec-driven-workflow --skill sdd -g
+```
+
+The skill router reassesses the workspace on each invocation, loads the correct SDD phase reference, and continues from persisted artifacts in `docs/specs/`.
+
+Compatibility notes:
+
+- Agent support for skills and allowed tools varies by assistant.
+- Use `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out of telemetry when running the `skills.sh` CLI.
+
+#### Option C: Manual Copy-Paste (No Installation)
 
 Copy the contents of a prompt file directly from `prompts/` and paste it into your AI chat. The AI will follow the structured instructions in the prompt.
 
 ### Quick "try it" flow
 
-1. Run `/SDD-1-generate-spec` and describe the feature you want. If the AI determines material clarification is needed, answer the generated questions file before continuing.
-2. Next, use `/SDD-2-generate-task-list-from-spec` pointing it at the generated spec; complete task generation, baseline planning commit, planning audit, and user-approved remediation if needed.
-3. Then execute `/SDD-3-manage-tasks` to implement tasks one at a time (creating proof artifacts before commits) after the SDD-2 audit required gates pass.
-4. Finally, apply `/SDD-4-validate-spec-implementation` to verify the implementation against the spec.
+1. Start SDD for a new feature.
+2. Continue SDD with task planning.
+3. Continue SDD with implementation.
+4. Continue SDD with validation.
+
+For slash-command installs, the equivalent commands are `/SDD-1-generate-spec`, `/SDD-2-generate-task-list-from-spec`, `/SDD-3-manage-tasks`, and `/SDD-4-validate-spec-implementation`.
 
 ## Details for the 4-step workflow
 
@@ -128,7 +160,7 @@ Each step uses a different prompt file and produces specific artifacts in `docs/
 - **Prompt-first workflow:** Use curated prompts to go from idea → spec → task list → implementation-ready backlog.
 - **Planning quality gate:** SDD-2 includes a mandatory audit with human-approved remediation before implementation starts.
 - **Predictable delivery:** Every step emphasizes demoable slices, proof artifacts, and collaboration with junior developers in mind.
-- **No dependencies required:** The prompts are plain Markdown files that work with any AI assistant.
+- **Flexible install paths:** Use prompt files for assistants with slash/custom prompt support, and a skill folder for assistants with skill-native workflows.
 - **Context verification:** Built-in emoji markers (SDD1️⃣-SDD4️⃣) detect when AI responses follow critical instructions, helping identify context rot issues early.
 
 ## Why Spec-Driven Development?
@@ -229,6 +261,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md). Please review [`CODE_OF_CONDUCT.md`](C
 | --- | --- | --- |
 | AI Dev Tasks | Foundational example of an SDD workflow expressed entirely in Markdown. | [snarktank/ai-dev-tasks](https://github.com/snarktank/ai-dev-tasks) |
 | Slash Command Manager | Utility for installing prompts as slash commands in AI assistants. | [liatrio-labs/slash-command-manager](https://github.com/liatrio-labs/slash-command-manager) |
+| skills.sh | CLI for installing repository skills into skill-native AI assistant workflows. | [skills.sh](https://skills.sh) |
 | MCP | Standard protocol for AI agent interoperability. | [modelcontextprotocol.io](https://modelcontextprotocol.io/docs/getting-started/intro) |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -100,20 +100,20 @@ npx skills add liatrio-labs/spec-driven-workflow --list
 npx skills add liatrio-labs/spec-driven-workflow --skill sdd
 
 # Install the SDD skill non-interactively
-npx -y skills add liatrio-labs/spec-driven-workflow --skill sdd
+npx skills add liatrio-labs/spec-driven-workflow --skill sdd --yes
 
 # Install to specific agents
 npx skills add liatrio-labs/spec-driven-workflow --skill sdd -a cursor -a codex
 
 # Install globally instead of project scope
-npx skills add liatrio-labs/spec-driven-workflow --skill sdd -g
+npx skills add liatrio-labs/spec-driven-workflow --skill sdd --global
 ```
 
 The skill router reassesses the workspace on each invocation, loads the correct SDD phase reference, and continues from persisted artifacts in `docs/specs/`.
 
 Compatibility notes:
 
-- Agent support for skills and allowed tools varies by assistant.
+- Agent support for skills and allowed tools varies by agent harness.
 - Use `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to opt out of telemetry when running the `skills.sh` CLI.
 
 #### Option C: Manual Copy-Paste (No Installation)
@@ -121,6 +121,15 @@ Compatibility notes:
 Copy the contents of a prompt file directly from `prompts/` and paste it into your AI chat. The AI will follow the structured instructions in the prompt.
 
 ### Quick "try it" flow
+
+For the slash-command installs via `slash-man`, invoke each step individually:
+
+1. Run `/SDD-1-generate-spec` and describe the feature you want. If the AI determines material clarification is needed, answer the generated questions file before continuing.
+2. Next, use `/SDD-2-generate-task-list-from-spec` pointing it at the generated spec; complete task generation, baseline planning commit, planning audit, and user-approved remediation if needed.
+3. Then execute `/SDD-3-manage-tasks` to implement tasks one at a time (creating proof artifacts before commits) after the SDD-2 audit required gates pass.
+4. Finally, apply `/SDD-4-validate-spec-implementation` to verify the implementation against the spec.
+
+If using the skill version, simply invoke the skill via your agent harness, usually `/sdd`. If in `codex`, it will be `$sdd`. You can supply a feature/idea/task along with the skill invocation to guide the skill, or just let the skill auto-detect the appropriate stage for you.
 
 1. Start SDD for a new feature.
 2. Continue SDD with task planning.

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -3,9 +3,11 @@ language: en
 
 words:
   - Liatrio
+  - Promptfoo
   - SDD
   - demoable
   - pyproject
+  - pytest
 
 ignorePaths:
   - .git/**

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,12 @@
+# Testing
+
+Run the deterministic skill validation tests and repository quality gates before submitting changes:
+
+```bash
+python -m pytest -q
+pre-commit run --all-files
+```
+
+The pytest suite covers the skill workspace-assessment script and static skill contract checks. These tests keep the new `skill/` install path verifiable without requiring live AI-agent execution.
+
+Promptfoo evaluations are tracked separately from this first skill-install integration milestone. The initial gate is deterministic script behavior plus static skill contract checks.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,12 +1,13 @@
 # Testing
 
-Run the deterministic skill validation tests and repository quality gates before submitting changes:
+Run the repository quality gate before submitting changes:
 
 ```bash
-python -m pytest -q
 pre-commit run --all-files
 ```
 
-The pytest suite covers the skill workspace-assessment script and static skill contract checks. These tests keep the new `skill/` install path verifiable without requiring live AI-agent execution.
+The pre-commit gate runs the deterministic pytest suite first, then checks YAML syntax, Markdown formatting, spelling, committed secrets, and commit-message format where applicable. The pytest suite covers the skill workspace-assessment script and static skill contract checks. These tests keep the new `skill/` install path verifiable without requiring live AI-agent execution.
+
+CI runs the same deterministic skill tests explicitly before `pre-commit run --all-files`, so failures are visible as a dedicated CI step and also enforced locally through pre-commit.
 
 Promptfoo evaluations are tracked separately from this first skill-install integration milestone. The initial gate is deterministic script behavior plus static skill contract checks.

--- a/docs/ai-native-development-primitives.html
+++ b/docs/ai-native-development-primitives.html
@@ -631,7 +631,7 @@
                             Reference Materials</a>
                         <a class="next-step-link" href="ai-techniques.html">Return to the Overview</a>
                         <a class="next-step-link" href="https://github.com/liatrio-labs/spec-driven-workflow"
-                            target="_blank" rel="noopener noreferrer">Read teh Prompts</a>
+                            target="_blank" rel="noopener noreferrer">View Workflow Source</a>
                     </div>
                 </div>
             </div>

--- a/docs/ai-native-development-primitives.html
+++ b/docs/ai-native-development-primitives.html
@@ -624,14 +624,14 @@
 
                 <div class="next-step-cta">
                     <h3>Continue the Learning Path</h3>
-                    <p>Compare the overview, the reference run, and the actual prompts to see how the same primitives
-                        repeat across the workflow.</p>
+                    <p>Compare the overview, the reference run, and the workflow source to see how the same primitives
+                        repeat across prompts and the skill.</p>
                     <div class="next-step-actions">
                         <a class="next-step-link next-step-link-primary" href="reference-materials.html">Browse
                             Reference Materials</a>
                         <a class="next-step-link" href="ai-techniques.html">Return to the Overview</a>
-                        <a class="next-step-link" href="https://github.com/liatrio-labs/spec-driven-workflow/tree/main/prompts"
-                            target="_blank" rel="noopener noreferrer">Read the Prompts</a>
+                        <a class="next-step-link" href="https://github.com/liatrio-labs/spec-driven-workflow"
+                            target="_blank" rel="noopener noreferrer">Read teh Prompts</a>
                     </div>
                 </div>
             </div>

--- a/docs/ai-techniques.html
+++ b/docs/ai-techniques.html
@@ -202,7 +202,7 @@
                         <a class="next-step-link next-step-link-primary" href="reference-materials.html">Browse
                             Reference Materials</a>
                         <a class="next-step-link" href="https://github.com/liatrio-labs/spec-driven-workflow"
-                            target="_blank" rel="noopener noreferrer">Read the Prompts</a>
+                            target="_blank" rel="noopener noreferrer">View Workflow Source</a>
                     </div>
                 </div>
             </div>

--- a/docs/ai-techniques.html
+++ b/docs/ai-techniques.html
@@ -201,7 +201,7 @@
                             href="ai-native-development-primitives.html">Read the Deep Dive</a>
                         <a class="next-step-link next-step-link-primary" href="reference-materials.html">Browse
                             Reference Materials</a>
-                        <a class="next-step-link" href="https://github.com/liatrio-labs/spec-driven-workflow/tree/main/prompts"
+                        <a class="next-step-link" href="https://github.com/liatrio-labs/spec-driven-workflow"
                             target="_blank" rel="noopener noreferrer">Read the Prompts</a>
                     </div>
                 </div>

--- a/docs/common-questions.html
+++ b/docs/common-questions.html
@@ -31,8 +31,8 @@
                         reports, we demonstrate how well-executed SDD works in practice. You can inspect the full
                         example in <a href="reference-materials.html">Reference Materials</a>.</p>
                     <p>It also highlights something easy to miss: <em>SDD keeps its method visible</em>. The workflow is not
-                        hidden behind a product layer, allowing teams to inspect the prompts and understand the
-                        patterns that drive the workflow. This accessibility enables teams to improve their skills
+                        hidden behind a product layer, allowing teams to inspect the prompt and skill instructions and
+                        understand the patterns that drive the workflow. This accessibility enables teams to improve their skills
                         with AI as they learn SDD.</p>
                 </div>
             </div>
@@ -419,7 +419,7 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                             </svg>
                         </div>
                         <h4>How Verification Markers Work</h4>
-                        <p>Each prompt instructs the AI to always begin responses with its specific marker (SDD1️⃣ for
+                        <p>Each phase instructs the AI to always begin responses with its specific marker (SDD1️⃣ for
                             spec generation, SDD2️⃣ for task breakdown, etc.). When you see the marker, it's an
                             <strong>indicator</strong> that critical instructions are probably being followed. If the
                             marker disappears, it's an immediate signal that context instructions may have been lost.
@@ -469,8 +469,8 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
 
                 <div class="next-step-cta">
                     <h3>Continue Evaluating the Workflow</h3>
-                    <p>Watch the short walkthrough next, then dive into the real prompts, proofs, and validation
-                        artifacts behind the workflow.</p>
+                    <p>Watch the short walkthrough next, then dive into the real workflow instructions, proofs, and
+                        validation artifacts behind the workflow.</p>
                     <div class="next-step-actions">
                         <a class="next-step-link next-step-link-primary" href="video-overview.html">Watch the Overview
                             Video</a>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Comparison: Liatrio's Prompts vs. Other Structured Development Tools - Spec-Driven Development</title>
+    <title>Comparison: Liatrio SDD vs. Other Structured Development Tools - Spec-Driven Development</title>
     <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link rel="stylesheet" href="assets/css/fonts.css">
@@ -25,9 +25,9 @@
                 <h1>Comparing SDD to Other Structured Development Tools</h1>
                 <div class="hero-content">
                     <p>Kiro, SpecKit, and Taskmaster each add structure to AI-assisted development, but they do so
-                        through very different operating models. This page compares Liatrio's four repo-local SDD
-                        prompts with those tools, with a focus on setup, workflow fit, and day-to-day adoption cost.</p>
-                    <p>A second distinction matters just as much: SDD exposes its logic in plain markdown, so teams can
+                        through very different operating models. This page compares Liatrio's repo-local SDD workflow
+                        with those tools, with a focus on setup, workflow fit, and day-to-day adoption cost.</p>
+                    <p>A second distinction matters just as much: SDD exposes its prompt and skill logic in plain markdown, so teams can
                         learn the patterns behind effective AI collaboration instead of depending on a product to hide
                         or mediate them.</p>
                 </div>
@@ -37,8 +37,8 @@
         <!-- Comparison Section -->
         <section class="phases-detailed">
             <div class="container">
-                <h2>Comparison: Liatrio's Prompts vs. Other Structured Development Tools</h2>
-                <p class="section-intro">The table below compares Liatrio's prompts with three other structured
+                <h2>Comparison: Liatrio SDD vs. Other Structured Development Tools</h2>
+                <p class="section-intro">The table below compares Liatrio's SDD workflow with three other structured
                     development approaches. The emphasis is less on feature lists and more on the practical cost of
                     adopting each system inside an existing engineering workflow, including whether the workflow itself
                     is something engineers can inspect and learn from.</p>
@@ -48,7 +48,7 @@
                         <thead>
                             <tr>
                                 <th>Feature</th>
-                                <th>Liatrio's SDD Prompts</th>
+                                <th>Liatrio SDD Workflow</th>
                                 <th>Kiro</th>
                                 <th>SpecKit</th>
                                 <th>Taskmaster</th>
@@ -58,8 +58,7 @@
                             <tr>
                                 <td><strong>Setup & Installation</strong></td>
                                 <td>✅ <a href="https://github.com/liatrio-labs/spec-driven-workflow" target="_blank"
-                                        rel="noopener noreferrer">Four markdown files
-                                        added as prompts within your existing workflow</a></td>
+                                        rel="noopener noreferrer">A simple 4-phase workflow installed as custom prompts or a single skill</a></td>
                                 <td>❌ <a href="https://kiro.dev/downloads/" target="_blank"
                                         rel="noopener noreferrer">Requires installing Kiro, signing in, and
                                         learning its product-specific workflow model</a>
@@ -74,14 +73,14 @@
                             </tr>
                             <tr>
                                 <td><strong>Editor/IDE Dependency</strong></td>
-                                <td>✅ Works in editors that support prompts or slash commands</td>
+                                <td>✅ Works in editors that support prompts, slash commands, or skill-native workflows</td>
                                 <td>❌ Structured workflow assumes the Kiro IDE as the primary environment</td>
                                 <td>⚠️ Runs in existing editors through generated agent commands</td>
                                 <td>⚠️ Works in existing editors through CLI or MCP integration</td>
                             </tr>
                             <tr>
                                 <td><strong>AI Assistant Compatibility</strong></td>
-                                <td>✅ Works with assistants that support custom prompts or slash commands</td>
+                                <td>✅ Works with assistants that support custom prompts, slash commands, or agent skills</td>
                                 <td>⚠️ Uses Kiro's built-in agent experience, model options, and product-specific modes
                                 </td>
                                 <td>⚠️ Works through supported agent integrations and slash commands</td>
@@ -89,7 +88,7 @@
                             </tr>
                             <tr>
                                 <td><strong>Learning Curve</strong></td>
-                                <td>✅ Uses a guided four-prompt workflow layered onto your existing workflow</td>
+                                <td>✅ Uses a guided four-phase workflow layered onto your existing workflow</td>
                                 <td>❌ Requires learning Kiro's broader vocabulary and workflow model
                                     (<code>specs</code>,
                                     <code>steering</code>, <code>hooks</code>, <code>powers</code>,
@@ -104,8 +103,8 @@
                             </tr>
                             <tr>
                                 <td><strong>Transparency</strong></td>
-                                <td>✅ Prompts are plain markdown, so the workflow logic is directly readable, editable,
-                                    and teachable</td>
+                                <td>✅ Prompt and skill instructions are plain markdown, so the workflow logic is directly readable,
+                                    editable, and teachable</td>
                                 <td>⚠️ Some files are editable, but core behavior, modes, and workflow concepts live in
                                     the product</td>
                                 <td>⚠️ Workflow files and templates are published on GitHub, but much of the method is
@@ -115,7 +114,7 @@
                             </tr>
                             <tr>
                                 <td><strong>Flexibility</strong></td>
-                                <td>✅ Prompt text can be edited to match team or project conventions</td>
+                                <td>✅ Prompt or skill text can be adapted to match team or project conventions</td>
                                 <td>⚠️ Steering files, hooks, and modes are configurable within Kiro's product model
                                 </td>
                                 <td>⚠️ Templates can be adapted, but the workflow, artifacts, and process vocabulary
@@ -148,7 +147,7 @@
                             </tr>
                             <tr>
                                 <td><strong>Speed</strong></td>
-                                <td>✅ Minimal setup overhead once prompts are installed</td>
+                                <td>✅ Minimal setup overhead once the prompt or skill path is selected</td>
                                 <td>❌ Front-loaded overhead is high because teams must learn the product model before
                                     moving quickly</td>
                                 <td>❌ Front-loaded overhead is high because the workflow generates and coordinates many
@@ -158,7 +157,7 @@
                             </tr>
                             <tr>
                                 <td><strong>Cost</strong></td>
-                                <td>✅ Markdown files are free to use</td>
+                                <td>✅ Markdown prompt and skill files are free to use</td>
                                 <td>⚠️ Free tier available, but usage is managed through sign-in, credits, and paid
                                     usage tiers</td>
                                 <td>✅ Open source</td>
@@ -175,20 +174,16 @@
             <div class="container">
                 <div class="installation-highlight">
                     <h2>Repo-Native Setup</h2>
-                    <p>The SDD workflow prompts can be installed
-                        in any AI assistant in seconds using the <a
-                            href="https://github.com/liatrio-labs/slash-command-manager" target="_blank"
-                            rel="noopener noreferrer">slash-command-manager</a>. This open-source tool from Liatrio
-                        makes it straightforward
-                        to add the prompts as slash commands in VS Code, Cursor, Claude Code, and many other AI tools
-                        that support custom commands.</p>
+                    <p>The SDD workflow can enter a repo through the path that best fits the assistant: prompt files
+                        for slash/custom command workflows, a skill folder for skill-native agents, or manual
+                        copy-paste for teams that want no installation at all.</p>
                     <p>Because the workflow is plain markdown, teams can adopt it without taking on a new IDE, a
                         generated artifact model, or a separate task-orchestration system. See the <a
                             href="https://github.com/liatrio-labs/spec-driven-workflow#tldr--quickstart" target="_blank"
-                            rel="noopener noreferrer">installation instructions in the README</a> to get started.</p>
-                    <p>That same simplicity also makes SDD useful as a teaching tool: engineers can read the prompts,
-                        understand the workflow patterns they encode, and reuse those patterns when working with AI in
-                        other contexts.</p>
+                            rel="noopener noreferrer">GitHub README quickstart</a> for current setup details.</p>
+                    <p>That same simplicity also makes SDD useful as a teaching tool: engineers can read the workflow
+                        instructions, understand the patterns they encode, and reuse those patterns when working with AI
+                        in other contexts.</p>
                 </div>
             </div>
         </section>
@@ -198,13 +193,13 @@
             <div class="container">
                 <h2>The Bottom Line</h2>
                 <p>For teams working in existing enterprise codebases, the main tradeoff is not whether a tool offers
-                    structure, but how much new product or process it asks engineers to adopt. Liatrio's prompts aim to
+                    structure, but how much new product or process it asks engineers to adopt. Liatrio's SDD workflow aims to
                     provide structure in a repo-native form: readable markdown, editable conventions, and a workflow
                     that can sit on top of existing tools rather than replace them.</p>
                 <p>This pattern extends beyond Kiro, SpecKit, and Taskmaster. Other spec-driven frameworks such as
                     Tessl and BMAD also add structure by introducing a larger system around the developer: more
                     tooling, more workflow machinery, and more framework-specific concepts to absorb. Liatrio's SDD
-                    prompts are intentionally different. They expose the workflow logic directly in markdown, so teams
+                    workflow is intentionally different. It exposes the workflow logic directly in markdown, so teams
                     can inspect it, adapt it, and internalize better AI collaboration patterns instead of depending on
                     a mediated system.</p>
 

--- a/docs/developer-experience.html
+++ b/docs/developer-experience.html
@@ -33,7 +33,7 @@
                         in <a href="reference-materials.html">Reference Materials</a>. We'll first explore the
                         traditional manual approach to establish a baseline, then reveal how AI assistance transforms
                         the entire development lifecycle from hours of toil into minutes of strategic oversight.</p>
-                    <p>Just as importantly, SDD keeps the workflow logic visible. The prompts, specs, tasks, proofs,
+                    <p>Just as importantly, SDD keeps the workflow logic visible. The instructions, specs, tasks, proofs,
                         and validation artifacts make the method readable, so teams can learn how to guide AI well
                         instead of relying on hidden product behavior.</p>
                 </div>
@@ -313,7 +313,7 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                     </div>
                     <div class="shift-item">
                         <h4>Teachable AI Collaboration</h4>
-                        <p>Because SDD exposes the workflow in readable prompts and artifacts, developers can study the
+                        <p>Because SDD exposes the workflow in readable instructions and artifacts, developers can study the
                             method itself and improve how they interact with AI over time.</p>
                     </div>
                 </div>
@@ -347,7 +347,7 @@ CSpell: Files checked: 1, Issues found: 2 in 1 file.</code></pre>
                     </div>
                     <div class="benefits-column redefining-card">
                         <h4>Visible Working Method</h4>
-                        <p>The prompts and artifacts make effective AI-assisted engineering visible, which helps
+                        <p>The workflow instructions and artifacts make effective AI-assisted engineering visible, which helps
                             teams build shared habits and judgment instead of depending on hidden workflow logic.</p>
                     </div>
                 </div>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ Use one of three paths: install `prompts/` as slash commands for assistants with
 
 ## Do we need any prerequisites?
 
-The workflow runs with minimal setup—many teams start with the prompts alone and layer in automation when they are ready.
+The workflow runs with minimal setup—many teams start with prompts, the skill path, or manual copy-paste and layer in automation when they are ready.
 
 ## How does it work with different tools?
 
@@ -24,15 +24,15 @@ The workflow is designed to be usable with many different AI agents and work‑t
 
 ## What makes it different from documentation templates?
 
-Templates stay static; the workflow ships as a versioned package that you upgrade like any package, so improvements arrive without overwriting your customizations. The workflow also provides working commands and tools, not just documentation guidelines.
+Templates stay static; the workflow ships as a versioned package that you upgrade like any package, so improvements arrive without overwriting your customizations. The workflow also provides working commands, skill guidance, and tools, not just documentation guidelines.
 
 ## What if we already have an established process?
 
-You keep it. The workflow provides commands that wire into your existing project structure—your current ADR folders, ticket conventions, or roadmaps. You don't need to rewrite your documentation or reorganize your repos. The workflow layers consistency on top of what is already working.
+You keep it. The workflow provides commands or skill guidance that wire into your existing project structure—your current ADR folders, ticket conventions, or roadmaps. You don't need to rewrite your documentation or reorganize your repos. The workflow layers consistency on top of what is already working.
 
 ## How does it guide iteration size?
 
-Commands and scaffolds steer teams toward skateboard‑to‑scooter increments: create small testable slices, validate learning, and only then scale. Prompts explicitly ask you to define the skateboard (minimal testable value), scooter (enhanced but still lean), and car (complete product) so teams discuss iteration sizes up front.
+Commands, skill guidance, and scaffolds steer teams toward skateboard‑to‑scooter increments: create small testable slices, validate learning, and only then scale. Prompts explicitly ask you to define the skateboard (minimal testable value), scooter (enhanced but still lean), and car (complete product) so teams discuss iteration sizes up front.
 
 ## Can it work entirely in Markdown in one repo?
 
@@ -56,7 +56,7 @@ Through layering. Local overrides and configuration live outside the distributed
 
 ## What's the learning curve?
 
-Minimal. If you can write Markdown, you can use the workflow. The templates and commands guide you through the process. Most teams are productive in their first session.
+Minimal. If you can write Markdown, you can use the workflow. The prompts, skill guidance, and commands guide you through the process. Most teams are productive in their first session.
 
 ## Why adopt a spec‑driven workflow now?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ Any team trying to level up AI‑native delivery. You can adopt the workflow a p
 
 ## How is it installed?
 
-Teams install the workflow via package managers or MCP, then use its commands to maintain context, drive consistent work breakdown, and keep AI agents operating inside agreed guardrails.
+Use one of three paths: install `prompts/` as slash commands for assistants with slash/custom prompt support, install `skill/` as an agent skill for assistants with skill-native workflows, or manually copy prompt contents into an AI chat. All paths keep workflow artifacts in `docs/specs/` so teams can maintain context, drive consistent work breakdown, and keep AI agents operating inside agreed guardrails.
 
 ## Do we need any prerequisites?
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,16 +25,20 @@
                 <h1>The Spec-Driven Development (SDD) Playbook</h1>
                 <div class="hero-content">
                     <p>Complete a feature in minutes, not days. Liatrio's Spec-Driven Development workflow is
-                        <strong>4 markdown prompts plus a skill-native install option</strong> that help developers guide an AI assistant through
+                        <strong>four lightweight phases available as prompts or an agent skill</strong> that help developers guide an AI assistant through
                         implementing their day-to-day work with structure, clarity, and evidence.
                     </p>
-                    <p>These prompts are <strong>transparent</strong> and <strong>learnable</strong>: you can read
-                        every prompt, understand the workflow logic it applies, and adapt the patterns to your own team
-                        and projects. Instead of hiding the method inside a product, SDD exposes it in markdown.</p>
-                    <p>They are also <strong>tool-agnostic</strong>: use prompt files for assistants with slash/custom prompt support, and a skill folder for assistants with skill-native workflows. They create a simple file
-                        structure in <code>docs/specs/</code> that doesn't pollute your repo.
+                    <p>The workflow instructions are <strong>transparent</strong> and <strong>learnable</strong>: you can read
+                        the prompt and skill source, understand the workflow logic it applies, and adapt the patterns to
+                        your own team and projects. Instead of hiding the method inside a product, SDD exposes it in markdown.</p>
+                    <p>They are also <strong>tool-agnostic</strong>: use prompt files for assistants with slash/custom
+                        prompt support, and a skill folder for assistants with skill-native workflows. They create a
+                        simple file structure in <code>docs/specs/</code> that doesn't pollute your repo.
                     </p>
-                    <p>View the install artifacts on GitHub: <a
+                    <p>Choose the path that fits your assistant—prompt files, the skill folder, or manual copy-paste—and
+                        use the <a href="https://github.com/liatrio-labs/spec-driven-workflow#tldr--quickstart"
+                            target="_blank" rel="noopener noreferrer">GitHub README quickstart</a> for setup details.</p>
+                    <p>View the source artifacts on GitHub: <a
                             href="https://github.com/liatrio-labs/spec-driven-workflow/tree/main/prompts"
                             target="_blank"
                             rel="noopener noreferrer">prompts/</a> and <a
@@ -46,15 +50,15 @@
                 <!-- Flow Input Section -->
                 <div class="flow-input-section">
                     <h3>What You Bring: Flow Input</h3>
-                    <p>Start with anything: an idea, a Jira story, a GitHub issue, or a feature request. The prompts
-                        adapt to your input and guide you through the workflow. No special format required—just describe
+                    <p>Start with anything: an idea, a Jira story, a GitHub issue, or a feature request. The workflow
+                        adapts to your input and guides you through each phase. No special format required—just describe
                         what you want to build.</p>
                 </div>
 
                 <!-- Scope Validation Section -->
                 <div class="scope-validation-section">
                     <h3>Built-in Scope Validation</h3>
-                    <p>The prompts automatically check if your work is appropriately sized. If it's <strong>too
+                    <p>The workflow automatically checks if your work is appropriately sized. If it's <strong>too
                             large</strong>, they'll suggest splitting it into smaller specs. If it's <strong>too
                             small</strong>, they'll suggest direct implementation. Perfect for well-scoped features that
                         are ready to implement.</p>
@@ -81,13 +85,14 @@
         <section class="phases-detailed">
             <div class="container">
                 <h2>The Four Steps</h2>
-                <p class="section-intro">One person runs through these 4 prompts sequentially with an AI assistant. In
+                <p class="section-intro">One person runs through these four workflow phases sequentially with an AI assistant. In
                     the <a href="reference-materials.html">cspell pre-commit hook example</a> featured across this
                     site, the end-to-end workflow took less than 15 minutes from start to finish. The highest-leverage
                     work happens in Step 1 and Step 2: when the spec is clear and the task plan is concrete,
                     implementation and validation are far more likely to run smoothly without human rescue. Because the
-                    prompts are readable, the workflow also doubles as a guide for learning how to scope work, guide
-                    AI, and verify results more effectively.</p>
+                    workflow instructions are readable, SDD also doubles as a guide for learning how to scope work,
+                    guide AI, and verify results more effectively. Prompt installs expose the individual phase files;
+                    skill installs route through the same phase logic from the skill source.</p>
 
                 <div class="phases-grid">
                     <div class="phase-card">
@@ -98,13 +103,13 @@
                         <div class="phase-card-content">
                             <p><strong>Focus:</strong> Lock down scope, intent, and success criteria before any code is
                                 written.</p>
-                            <p><strong>What It Does:</strong> The prompt validates scope (too large/too small/just
+                            <p><strong>What It Does:</strong> The phase validates scope (too large/too small/just
                                 right), resolves ambiguous context, and generates a specification document with clear
                                 boundaries.</p>
                             <p><strong>Output:</strong> A markdown spec file in
                                 <code>docs/specs/[NN]-spec-[feature-name]/</code>
                             </p>
-                            <p><strong>Prompt:</strong> <a
+                            <p><strong>Prompt reference:</strong> <a
                                     href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-1-generate-spec.md"
                                     target="_blank" rel="noopener noreferrer">SDD-1-generate-spec.md</a></p>
                         </div>
@@ -123,7 +128,7 @@
                                 caught before implementation starts.</p>
                             <p><strong>Output:</strong> A task list markdown file with demo criteria and proof artifact
                                 requirements</p>
-                            <p><strong>Prompt:</strong> <a
+                            <p><strong>Prompt reference:</strong> <a
                                     href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-2-generate-task-list-from-spec.md"
                                     target="_blank" rel="noopener noreferrer">SDD-2-generate-task-list-from-spec.md</a>
                             </p>
@@ -142,7 +147,7 @@
                                 (continuous/task/batch), creates proof artifacts, and manages git commits.</p>
                             <p><strong>Output:</strong> Working code, proof artifact files, and task-aligned git commits
                             </p>
-                            <p><strong>Prompt:</strong> <a
+                            <p><strong>Prompt reference:</strong> <a
                                     href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-3-manage-tasks.md"
                                     target="_blank" rel="noopener noreferrer">SDD-3-manage-tasks.md</a></p>
                         </div>
@@ -160,7 +165,7 @@
                                 checks file integrity, and produces a validation report.</p>
                             <p><strong>Output:</strong> A validation report with PASS/FAIL gates and evidence-based
                                 coverage matrix</p>
-                            <p><strong>Prompt:</strong> <a
+                            <p><strong>Prompt reference:</strong> <a
                                     href="https://github.com/liatrio-labs/spec-driven-workflow/blob/main/prompts/SDD-4-validate-spec-implementation.md"
                                     target="_blank" rel="noopener noreferrer">SDD-4-validate-spec-implementation.md</a>
                             </p>
@@ -180,7 +185,7 @@
                         <ul>
                             <li>Built-in scope validation prevents oversized work</li>
                             <li>Early clarification makes later course correction cheaper and less likely</li>
-                            <li>Readable prompts expose patterns teams can study and adapt</li>
+                            <li>Readable workflow instructions expose patterns teams can study and adapt</li>
                             <li>Tool-agnostic—works with any AI assistant</li>
                             <li>Artifact storage stays lightweight and can adapt to your environment</li>
                             <li>Context verification markers detect instruction loss early</li>
@@ -200,7 +205,7 @@
                 <!-- Context Verification Section -->
                 <div class="scope-validation-section" style="margin-top: 2rem;">
                     <h3>Built-in Context Verification</h3>
-                    <p>Each prompt includes a verification marker (SDD1️⃣, SDD2️⃣, SDD3️⃣, SDD4️⃣) that appears at the
+                    <p>Each phase includes a verification marker (SDD1️⃣, SDD2️⃣, SDD3️⃣, SDD4️⃣) that appears at the
                         start of AI responses. These markers help detect <strong>context rot</strong>—a silent failure
                         mode where AI performance degrades as input context length increases, even when tasks remain
                         simple.</p>
@@ -210,16 +215,16 @@
                 </div>
 
                 <div class="comparison-cta">
-                    <p><strong>How does this compare to other structured development tools?</strong> See our <a
+                    <p><strong>How does this compare to other structured development tools?</strong></p><br><p> See our <a
                             href="comparison.html">comparison against Kiro, SpecKit, and Taskmaster</a> to understand
-                        why Liatrio's prompts fit better into the typical workflow of software developers doing
+                        why Liatrio's SDD workflow fits better into the typical workflow of software developers doing
                         day-to-day work, and why exposing the workflow logic matters just as much as lightweight
                         adoption.</p>
                 </div>
-
+                <br>
                 <div class="comparison-cta">
-                    <p><strong>Want to study the patterns behind the workflow?</strong> Explore <a
-                            href="ai-techniques.html">AI Techniques in SDD</a> to see how the prompts use task
+                    <p><strong>Want to study the patterns behind the workflow?</strong></p><br><p>Explore <a
+                            href="ai-techniques.html">AI Techniques in SDD</a> to see how the workflow uses task
                         decomposition, progressive disclosure, structured outputs, and evidence-based validation to make
                         AI-assisted work more teachable.</p>
                 </div>
@@ -272,7 +277,7 @@
         <section class="reactive-art progression-section">
             <div class="container">
                 <h2>From Reactive Art to Predictable Engineering</h2>
-                <p>By consistently using these four prompts, developers transform small feature work from reactive
+                <p>By consistently using these four phases, developers transform small feature work from reactive
                     coding into predictable, evidence-based implementation. Liatrio's Spec-Driven Development workflow
                     creates a self-documenting, auditable process that systematically drives up quality, reduces
                     ambiguity, and ensures every feature delivered is a feature validated—all in minutes, not days.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,20 +25,22 @@
                 <h1>The Spec-Driven Development (SDD) Playbook</h1>
                 <div class="hero-content">
                     <p>Complete a feature in minutes, not days. Liatrio's Spec-Driven Development workflow is
-                        <strong>just 4 markdown prompts</strong> that help developers guide an AI assistant through
+                        <strong>4 markdown prompts plus a skill-native install option</strong> that help developers guide an AI assistant through
                         implementing their day-to-day work with structure, clarity, and evidence.
                     </p>
                     <p>These prompts are <strong>transparent</strong> and <strong>learnable</strong>: you can read
                         every prompt, understand the workflow logic it applies, and adapt the patterns to your own team
                         and projects. Instead of hiding the method inside a product, SDD exposes it in markdown.</p>
-                    <p>They are also <strong>tool-agnostic</strong> (works with any AI assistant) and
-                        <strong>lightweight</strong> (no installation, no dependencies). They create a simple file
+                    <p>They are also <strong>tool-agnostic</strong>: use prompt files for assistants with slash/custom prompt support, and a skill folder for assistants with skill-native workflows. They create a simple file
                         structure in <code>docs/specs/</code> that doesn't pollute your repo.
                     </p>
-                    <p>View the prompts on GitHub: <a
+                    <p>View the install artifacts on GitHub: <a
                             href="https://github.com/liatrio-labs/spec-driven-workflow/tree/main/prompts"
                             target="_blank"
-                            rel="noopener noreferrer">github.com/liatrio-labs/spec-driven-workflow/prompts</a></p>
+                            rel="noopener noreferrer">prompts/</a> and <a
+                            href="https://github.com/liatrio-labs/spec-driven-workflow/tree/main/skill"
+                            target="_blank"
+                            rel="noopener noreferrer">skill/</a></p>
                 </div>
 
                 <!-- Flow Input Section -->

--- a/docs/press-release.md
+++ b/docs/press-release.md
@@ -10,7 +10,7 @@ Engineering teams adopting AI coding assistants face a challenge: each developer
 
 ## The Solution: Workflow as a Versioned Component
 
-Liatrio’s Spec‑Driven Workflow treats your development process like any other library in your stack. Install it via `npx` or use it as an MCP, and it wires consistent structured context, work breakdown patterns and AI‑agent guidance into your project — whether you’re working on a weekend prototype or a multi‑repo platform. It provides a stable foundation even as teams use different or evolving AI tools, creating consistency where tool diversity surfaces friction.
+Liatrio’s Spec‑Driven Workflow treats your development process like any other library in your stack. Adopt it through slash-command prompts, an agent skill, or manual Markdown guidance, and it wires consistent structured context, work breakdown patterns and AI‑agent guidance into your project — whether you’re working on a weekend prototype or a multi‑repo platform. It provides a stable foundation even as teams use different or evolving AI tools, creating consistency where tool diversity surfaces friction.
 
 The workflow features:
 
@@ -31,5 +31,5 @@ The workflow scales from solo developers to enterprise platforms:
 - **Single repository**: Keep everything local in Markdown files.
 - **Multi‑repository**: Maintain consistent context across repos with 1:1 mappings between context artifacts.
 - **External context storage**: Context can live outside repos entirely while maintaining the same structure.
-- **Prompt‑first**: Works with just prompts — no heavy tooling required.
+- **Prompt‑ or skill‑first**: Works without heavy platform tooling.
 - **Multi‑tool**: Use different AI agents and work‑tracking systems together in the same project.

--- a/docs/reference-materials.html
+++ b/docs/reference-materials.html
@@ -177,11 +177,11 @@
                 <div class="next-step-cta">
                     <h3>Ready to Apply SDD in Your Repo?</h3>
                     <p>Use these artifacts as a study guide, then connect them back to the broader AI-native
-                        development primitives behind the workflow or install the prompts in your own repository.</p>
+                        development primitives behind the workflow or apply SDD in your own repository.</p>
                     <div class="next-step-actions">
                         <a class="next-step-link next-step-link-primary"
                             href="https://github.com/liatrio-labs/spec-driven-workflow#tldr--quickstart" target="_blank"
-                            rel="noopener noreferrer">Open Quickstart</a>
+                            rel="noopener noreferrer">Open README Quickstart</a>
                         <a class="next-step-link" href="ai-native-development-primitives.html">Study the
                             Primitives</a>
                         <a class="next-step-link" href="ai-techniques.html">Return to the Overview</a>

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,7 +24,7 @@ If multiple active specs exist and the user request does not clearly identify on
 Before routing, run the bundled assessor script while the current working directory is the target repository/workspace root:
 
 ```bash
-python {{skill_dir}}/scripts/assess-sdd-state.py .
+python3 {{skill_dir}}/scripts/assess-sdd-state.py .
 ```
 
 `{{skill_dir}}` locates bundled skill assets only; SDD artifacts are assessed from the workspace path argument (`.` in the command above). The script outputs JSON describing active specs and a recommended phase. Use that output as the default source of truth for routing.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: sdd
+description: "Execute the Spec-Driven Development (SDD) workflow as a skill-native alternate install option for agents that support skills instead of custom prompts."
+---
+
+# Spec-Driven Workflow Orchestrator
+
+You are the orchestrator for the Spec-Driven Development (SDD) workflow. Determine the current lifecycle phase from the workspace, then load and follow the single matching phase reference.
+
+## Skill Contract
+
+This skill manages one SDD phase per invocation unless the loaded phase explicitly requires a smaller checkpoint. It must:
+
+1. Assess workspace state before routing.
+2. Select exactly one active spec and one phase reference.
+3. Load only that phase reference.
+4. Execute the phase instructions or stop at a required approval gate.
+5. Tell the user the selected spec, detected state, current phase, chosen phase reference path, created or updated artifacts, and next recommended natural-language request.
+
+If multiple active specs exist and the user request does not clearly identify one, ask the user which spec to continue before modifying files. If the selection is unambiguous, state why that spec was selected.
+
+## State Assessment
+
+Before routing, run the bundled assessor script while the current working directory is the target repository/workspace root:
+
+```bash
+python {{skill_dir}}/scripts/assess-sdd-state.py .
+```
+
+`{{skill_dir}}` locates bundled skill assets only; SDD artifacts are assessed from the workspace path argument (`.` in the command above). The script outputs JSON describing active specs and a recommended phase. Use that output as the default source of truth for routing.
+
+Use manual inspection only if the script cannot run. When falling back manually, state that fallback explicitly, inspect `./docs/specs/`, and apply the same phase rules below.
+
+## Phase Rules
+
+- **Phase 1 — Spec Generation**
+  - **Condition:** The user requested a new feature, but no matching `[NN]-spec-[feature-name]/` directory exists, or the spec directory exists but the spec document is incomplete or missing.
+  - **Action:** Gather context and write the formal specification.
+
+- **Phase 2 — Task List Generation and Audit**
+  - **Condition:** `[NN]-spec-[feature-name].md` exists and is complete, but `[NN]-tasks-[feature-name].md` is missing, or the mandatory `[NN]-audit-[feature-name].md` planning audit has not been generated and passed.
+  - **Action:** Translate the spec into parent/sub-tasks, define Proof Artifacts, and run the mandatory planning audit gate.
+
+- **Phase 3 — Task Implementation**
+  - **Condition:** The spec, task list, and a passing planning audit report all exist, and there are incomplete tasks marked with `[ ]` or `[~]` in the task list.
+  - **Action:** Execute the task list, implement the code, and generate the required Proof Artifacts.
+
+- **Phase 4 — Validation**
+  - **Condition:** Implementation tasks are marked complete and the user asks to validate the work, or the assessor discovers an active spec where implementation appears finished and validation is missing or failing.
+  - **Action:** Evaluate the codebase and Proof Artifacts against the spec requirements using strict pass/fail quality gates.
+
+## Reference Routing
+
+After determining the phase, read only the corresponding bundled reference file:
+
+- **If Phase 1 applies:** `{{skill_dir}}/references/sdd-1-generate-spec.md`
+- **If Phase 2 applies:** `{{skill_dir}}/references/sdd-2-generate-task-list-from-spec.md`
+- **If Phase 3 applies:** `{{skill_dir}}/references/sdd-3-manage-tasks.md`
+- **If Phase 4 applies:** `{{skill_dir}}/references/sdd-4-validate-spec-implementation.md`
+
+Always defer to the detailed instructions, constraints, and anti-patterns in the chosen reference file.
+
+## User-Facing Reporting
+
+When beginning or handing off work, state the phase and selected spec in plain language:
+
+```markdown
+Current SDD phase: Phase N — <phase name>
+Selected spec: `docs/specs/NN-spec-feature/` (or `none yet — new spec will be created` when no spec exists)
+Phase reference: `<chosen bundled phase reference path>`
+Detected state: <state summary from assessor or manual fallback>
+Selection reason: <why this spec/phase was selected>
+```
+
+When a phase creates or updates files, include:
+
+- created or updated artifact paths
+- any approval gate reached
+- validation or audit outcome, when applicable
+- a `How to Continue the SDD Workflow` handoff using this exact spacing pattern:
+
+```markdown
+## How to Continue the SDD Workflow
+
+Likely next phase action: <what the skill will do next, or that the current workflow is complete>
+
+To continue the workflow in this chat, reply with:
+
+`<suggested natural-language reply>`
+
+You can also continue in a new chat if you want to keep context lean; the SDD skill will reassess repository state from the persisted concrete artifact set for the current phase, such as spec, task, audit, proof, or validation artifacts.
+```
+
+Use a blank line between every distinct part of the handoff: heading, likely next phase action, same-chat instruction, suggested reply, and new-chat option. Suggested replies include:
+
+- `Continue SDD with task planning.`
+- `Generate the sub-tasks.`
+- `Continue SDD with implementation.`
+- `Continue SDD with validation.`
+- `Start SDD for a new feature.`
+
+Do not label the handoff as a generic next-request section. Do not put the suggested reply before the likely next phase action. Do not compress the handoff into adjacent lines. Do not refer users to slash-style phase invocations, bundled reference filenames, or direct phase command names for continuation. The skill router reassesses workspace state on the next invocation and loads the correct reference.

--- a/skill/references/sdd-1-generate-spec.md
+++ b/skill/references/sdd-1-generate-spec.md
@@ -2,6 +2,14 @@
 
 This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
 
+## Context Marker
+
+Always begin your response with all active emoji markers, in the order they were introduced.
+
+Format:  "<marker1><marker2><marker3>\n<response>"
+
+The marker for this instruction is:  SDD1️⃣
+
 ## You are here in the workflow
 
 We are at the **beginning** of the Spec-Driven Development Workflow. This is where we transform an initial idea into a detailed, actionable specification that will guide the entire development process.

--- a/skill/references/sdd-1-generate-spec.md
+++ b/skill/references/sdd-1-generate-spec.md
@@ -1,0 +1,505 @@
+# Phase 1 — Generate Specification
+
+This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
+
+## You are here in the workflow
+
+We are at the **beginning** of the Spec-Driven Development Workflow. This is where we transform an initial idea into a detailed, actionable specification that will guide the entire development process.
+
+### Workflow Integration
+
+This spec serves as the **planning blueprint** for the entire SDD workflow:
+
+**Value Chain Flow:**
+
+- **Idea → Spec**: Transforms initial concept into structured requirements
+- **Spec → Tasks**: Provides foundation for implementation planning
+- **Tasks → Implementation**: Guides structured development approach
+- **Implementation → Validation**: Spec serves as acceptance criteria
+
+**Critical Dependencies:**
+
+- **User Stories** become the basis for proof artifacts in task generation
+- **Functional Requirements** drive implementation task breakdown
+- **Technical Considerations** inform architecture and dependency decisions
+- **Demoable Units** become parent task boundaries in task generation
+
+**What Breaks the Chain:**
+
+- Vague user stories → unclear proof artifacts and task boundaries
+- Missing functional requirements → gaps in implementation coverage
+- Inadequate technical considerations → architectural conflicts during implementation
+- Oversized specs → unmanageable task breakdown and loss of incremental progress
+
+## Your Role
+
+You are a **Senior Product Manager and Technical Lead** with extensive experience in software specification development. Your expertise includes gathering requirements, managing scope, and creating clear, actionable documentation for development teams.
+
+## Goal
+
+To create a comprehensive Specification (Spec) based on an initial user input. This spec will serve as the single source of truth for a feature. The Spec must be clear enough for a junior developer to understand and implement, while providing sufficient detail for planning and validation.
+
+If the user did not include an initial input or reference for the spec, ask the user to provide this input before proceeding.
+
+## Spec Generation Overview
+
+1. **Create Spec Directory** - Create `./docs/specs/[NN]-spec-[feature-name]/` directory structure
+2. **Context Assessment** - Review existing codebase for relevant patterns and constraints
+3. **Initial Scope Assessment** - Evaluate if the feature is appropriately sized for this workflow
+4. **Clarification Decision** - Decide whether the current context is sufficient or whether a questions file is required
+5. **Spec Generation** - Create the detailed specification document
+6. **Review and Refine** - Validate completeness and clarity with the user
+
+## Step 1: Create Spec Directory
+
+Create the spec directory structure before proceeding with any other steps. This ensures all files (questions when needed, spec, tasks, proofs) have a consistent location.
+
+**Directory Structure:**
+
+- **Path**: `./docs/specs/[NN]-spec-[feature-name]/` where `[NN]` is a zero-padded 2-digit sequence number (e.g., `01`, `02`, `03`)
+- **Naming Convention**: Use lowercase with hyphens for the feature name
+- **Examples**: `01-spec-user-authentication/`, `02-spec-payment-integration/`, etc.
+
+**Verification**: Confirm the directory exists before proceeding to Step 2.
+
+## Step 2: Context Assessment
+
+If working in a pre-existing project, begin by briefly reviewing the codebase and existing docs to understand:
+
+- Current architecture patterns and conventions
+- Relevant existing components or features
+- Integration constraints or dependencies
+- Files that might need modification or extension
+- **Repository Standards and Patterns**: Identify existing coding standards, architectural patterns, and development practices from:
+  - Project documentation (README.md, CONTRIBUTING.md, docs/)
+  - AI specific documentation (agent instruction files, if present, such as `AGENTS.md` or other repository-local AI guidance)
+  - Configuration files (package.json, Cargo.toml, pyproject.toml, etc.)
+  - Existing code structure and naming conventions
+  - Testing patterns and quality assurance practices
+  - Commit message conventions and development workflows
+
+**Use this context to inform scope validation and requirements, not to drive technical decisions.** Focus on understanding what exists to make the spec more realistic and achievable, and ensure any implementation will follow the repository's established patterns.
+
+### Latest Technology Standards Research (Required When Relevant)
+
+Before finalizing clarification status or generating the spec, identify the technologies, frameworks, platforms, libraries, or service categories that are explicitly mentioned or strongly implied by the request.
+
+For each technology that materially affects the spec:
+
+- Use web research to look up current best practices and standards beyond the model's training data.
+- Prioritize official documentation, vendor guidance, standards bodies, or other high-signal primary sources.
+- Prefer current-year guidance when available, then the previous year, before using older material.
+- Capture only the practices that materially affect feature design, validation, security, maintainability, or user experience.
+- Note any tension between repository patterns and current external guidance.
+
+Record a short internal research summary covering:
+
+- Technology researched
+- Source(s) consulted
+- Recency signal (publication/update date when available, otherwise note that the source is a living document)
+- 1-3 relevant best practices or standards
+- Any unresolved ambiguity that should be confirmed with the user
+
+If no technology-specific external guidance is relevant, explicitly state that no latest-standards research was needed.
+
+## Step 3: Initial Scope Assessment
+
+Evaluate whether this feature request is appropriately sized for this spec-driven workflow.
+
+**Private analysis guidance:**
+
+- Consider the complexity and scope of the requested feature
+- Compare against the following examples
+- Use context from Step 2 to inform the assessment
+- If scope is too large, suggest breaking into smaller specs
+- If scope is too small, suggest direct implementation without formal spec
+
+**Scope Examples:**
+
+**Too Large (split into multiple specs):**
+
+- Rewriting an entire application architecture or framework
+- Migrating a complete database system to a new technology
+- Refactoring multiple interconnected modules simultaneously
+- Implementing a full authentication system from scratch
+- Building a complete microservices architecture
+- Creating an entire admin dashboard with all features
+- Redesigning the entire UI/UX of an application
+- Implementing a comprehensive reporting system with all widgets
+
+**Too Small (vibe-code directly):**
+
+- Adding a single console.log statement for debugging
+- Changing the color of a button in CSS
+- Adding a missing import statement
+- Fixing a simple off-by-one error in a loop
+- Updating documentation for an existing function
+
+**Just Right (perfect for this workflow):**
+
+- Adding a new CLI flag with validation and help text
+- Implementing a single API endpoint with request/response validation
+- Refactoring one module while maintaining backward compatibility
+- Adding a new component with integration to existing state management
+- Creating a single database migration with rollback capability
+- Implementing one user story with complete end-to-end flow
+
+### Report Scope Assessment To User
+
+- **ALWAYS** inform the user of the result of the scope assessment.
+- If the scope appears inappropriate, **ALWAYS** pause the conversation to suggest alternatives and get input from the user.
+
+## Step 4: Clarification Sufficiency Check
+
+Assess whether you already have enough aligned context to write a high-quality spec without inventing requirements. Always err on the side of caution, but do not force a questions file when the available information is already sufficient.
+
+Focus on understanding the "what" and "why" rather than the "how."
+
+Use the following common areas to assess whether clarification is needed:
+
+**Core Understanding:**
+
+- What problem does this solve and for whom?
+- What specific functionality does this feature provide?
+
+**Success & Boundaries:**
+
+- How will we know it's working correctly?
+- What should this NOT do?
+- Are there edge cases we should explicitly include or exclude?
+
+**Design & Technical:**
+
+- Any existing design mockups or UI guidelines to follow?
+- Are there any technical constraints or integration requirements?
+
+**Proof Artifacts:**
+
+- What proof artifacts will demonstrate this feature works (URLs, CLI output, screenshots)?
+- What will each artifact demonstrate about the feature?
+
+**Progressive Disclosure:** Start with Core Understanding, then expand based on feature complexity and user responses.
+
+### Clarification Sufficiency Criteria
+
+Proceed without a questions file only if all of the following are true:
+
+- The user goal and intended outcome are clear.
+- Scope boundaries are clear enough to define meaningful non-goals.
+- Demoable Units and Proof Artifacts can be specified without guessing.
+- Known repository context and user-provided constraints are sufficient to avoid inventing requirements.
+- Relevant latest-standards research has been completed for material technologies, and it does not introduce unresolved approach choices that need user confirmation.
+- Any remaining uncertainty is minor and can safely be recorded in the spec's `Open Questions` section without reducing spec quality.
+
+Create a questions file if any of the following are true:
+
+- There are multiple materially different interpretations of the requested feature.
+- Acceptance criteria, Proof Artifacts, or Demoable Units would otherwise be guessed.
+- Scope boundaries or non-goals are unclear.
+- Design, technical, integration, security, or operational constraints are missing and would materially change the spec.
+- The user intent or direction could reasonably lead to different implementation paths.
+- Current best practices or standards for a relevant technology suggest multiple valid approaches, and the choice would materially affect the spec.
+- Repository patterns appear to conflict with current external guidance, and the correct direction is not obvious from the user's request.
+
+### Clarification Status Declaration (Required)
+
+Before proceeding, you MUST state exactly one of the following:
+
+- `Clarification status: sufficient - no questions file required`
+- `Clarification status: insufficient - questions file required`
+
+### Self-Verification Before Proceeding
+
+Before choosing `sufficient`, explicitly verify:
+
+- [ ] I am not guessing at missing requirements.
+- [ ] I can populate all major spec sections with grounded, user-aligned content.
+- [ ] I have reviewed relevant current best practices for material technologies, or I have explicitly determined that no external standards research is needed.
+- [ ] Any remaining uncertainty is non-blocking and belongs in `Open Questions` rather than a blocking questions round.
+
+If any check fails, create a questions file.
+
+### Questions File Format
+
+Follow this format exactly when you create a questions file.
+
+Each question MUST include recommended answer guidance for the user. Recommendations should reduce ambiguity, explain tradeoffs, and bias toward the option that best supports a clear, reviewable, junior-friendly spec.
+
+If a question is driven by latest-standards research, include a short note summarizing the relevant current guidance and why user confirmation is needed.
+
+```markdown
+# [NN] Questions Round 1 - [Feature Name]
+
+Please answer each question below (select one or more options, or add your own notes). Feel free to add additional context under any question.
+
+## 1. [Question Category/Topic]
+
+[What specific aspect of the feature needs clarification?]
+
+- [ ] (A) [Option description explaining what this choice means]
+- [ ] (B) [Option description explaining what this choice means]
+- [ ] (C) [Option description explaining what this choice means]
+- [ ] (D) [Option description explaining what this choice means]
+- [ ] (E) Other (describe)
+
+**Current best-practice context:** [Optional. Briefly summarize the latest relevant guidance or standard that makes this question important. Omit if not needed.]
+
+**Recommended answer(s):** [(A), (C)]
+
+**Why these are recommended:**
+
+- [Recommendation note 1 explaining why the suggested option best preserves user intent, reduces ambiguity, or improves spec quality]
+- [Recommendation note 2 explaining tradeoffs versus the other options]
+
+## 2. [Another Question Category/Topic]
+
+[What specific aspect of the feature needs clarification?]
+
+- [ ] (A) [Option description explaining what this choice means]
+- [ ] (B) [Option description explaining what this choice means]
+- [ ] (C) [Option description explaining what this choice means]
+- [ ] (D) [Option description explaining what this choice means]
+- [ ] (E) Other (describe)
+
+**Current best-practice context:** [Optional. Briefly summarize the latest relevant guidance or standard that makes this question important. Omit if not needed.]
+
+**Recommended answer(s):** [(B)]
+
+**Why these are recommended:**
+
+- [Recommendation note 1 explaining why the suggested option best preserves user intent, reduces ambiguity, or improves spec quality]
+- [Recommendation note 2 explaining tradeoffs versus the other options]
+```
+
+### Recommendation Rules For Questions Files
+
+When adding recommended answer guidance:
+
+- Recommend the option or combination of options that best supports alignment with the user's likely intent.
+- Explain why the recommendation is better than the alternatives presented, not just why it is reasonable in isolation.
+- Prefer recommendations that reduce avoidable ambiguity and make the eventual spec easier to validate.
+- Do not present recommendations as mandatory; the user remains the decision-maker.
+- If no option is clearly safer or more aligned, say so explicitly and explain the tradeoff instead of forcing a weak recommendation.
+- If recommending `Other`, provide a short suggested custom answer the user can edit.
+- When the question comes from latest-standards research, summarize the relevant current guidance in plain language before recommending an answer.
+- Use user confirmation to resolve meaningful tension between repository patterns and current external best practices.
+
+### Example Question With Recommendation Guidance
+
+Use this as a style reference for how to recommend answers without taking the decision away from the user.
+
+```markdown
+## 1. Authentication Entry Point
+
+Which sign-in methods should this first version support?
+
+- [ ] (A) Email and password only
+- [ ] (B) Google SSO only
+- [ ] (C) Email/password and Google SSO together
+- [ ] (D) Magic link only
+- [ ] (E) Other (describe)
+
+**Recommended answer(s):** [(A)]
+
+**Current best-practice context:** Current guidance for new authentication work often recommends shipping the smallest secure end-to-end slice first, then layering optional auth methods once the base flow is validated.
+
+**Why these are recommended:**
+
+- `(A)` is the smallest demoable slice and keeps the first spec focused on one complete authentication path.
+- `(A)` reduces ambiguity in validation, proof artifacts, and edge cases compared with `(C)`, which adds a second auth flow immediately.
+- `(B)` and `(D)` may still be valid product choices, but they introduce external-provider or email-delivery dependencies that are usually unnecessary unless the user explicitly wants them.
+- If the user already knows SSO is a hard requirement, they should override this recommendation.
+```
+
+### Questions File Process
+
+Only follow this process when clarification is insufficient.
+
+1. **Create Questions File**: Save questions to a file named `[NN]-questions-[N]-[feature-name].md` where `[N]` is the round number (starting at 1, incrementing for each new round).
+2. **Augment With Recommendations**: For every question, include recommended answer(s) and short justification notes comparing the recommendation to the other options.
+3. **Point User to File**: Direct the user to the questions file and instruct them to answer the questions directly in the file.
+4. **STOP AND WAIT**: Do not proceed to Step 5. Wait for the user to indicate they have saved their answers.
+5. **Read Answers**: After the user indicates they have saved their answers, read the file and continue the conversation.
+6. **Re-run Sufficiency Check**: Reassess whether the combined context is now sufficient to generate the spec.
+7. **Follow-Up Rounds**: If answers reveal new material ambiguity, create a new questions file with incremented round number (`[NN]-questions-[N+1]-[feature-name].md`) and repeat the process (return to step 3).
+
+**Iterative Process:**
+
+- If a user's answer reveals new material questions or areas needing clarification, ask follow-up questions in a new questions file.
+- Build on previous answers - use context from earlier responses to inform subsequent questions.
+- **CRITICAL**: After creating any questions file, you MUST STOP and wait for the user to provide answers before proceeding.
+- Only proceed to Step 5 after:
+  - You have received and reviewed all user answers to clarifying questions
+  - You have re-run the Clarification Sufficiency Check
+  - You have enough detail to populate all spec sections (User Stories, Demoable Units with functional requirements, etc.).
+
+## Step 5: Spec Generation
+
+Generate a comprehensive specification using this exact structure:
+
+```markdown
+# [NN]-spec-[feature-name].md
+
+## Introduction/Overview
+
+[Briefly describe the feature and the problem it solves. State the primary goal in 2-3 sentences.]
+
+## Goals
+
+[List 3-5 specific, measurable objectives for this feature. Use bullet points.]
+
+## User Stories
+
+[Focus on user motivation and WHY they need this. Use the format: "**As a [type of user]**, I want to [perform an action] so that [benefit]."]
+
+## Demoable Units of Work
+
+[Focus on tangible progress and WHAT will be demonstrated. Define 2-4 small, end-to-end vertical slices using the format below.]
+
+### [Unit 1]: [Title]
+
+**Purpose:** [What this slice accomplishes and who it serves]
+
+**Functional Requirements:**
+- The system shall [requirement 1: clear, testable, unambiguous]
+- The system shall [requirement 2: clear, testable, unambiguous]
+- The user shall [requirement 3: clear, testable, unambiguous]
+
+**Proof Artifacts:**
+- [Artifact type]: [description] demonstrates [what it proves]
+- Example: `Screenshot: `--help` output demonstrates new command exists`
+- Example: `CLI: `command --flag` returns expected output demonstrates feature works`
+
+### [Unit 2]: [Title]
+
+**Purpose:** [What this slice accomplishes and who it serves]
+
+**Functional Requirements:**
+- The system shall [requirement 1: clear, testable, unambiguous]
+- The system shall [requirement 2: clear, testable, unambiguous]
+
+**Proof Artifacts:**
+- [Artifact type]: [description] demonstrates [what it proves]
+- Example: `Test: MyFeature.test.ts passes demonstrates requirement implementation`
+- Example: `Order PDF: PDF downloaded from https://example.com/order-submitted shows completed flow demonstrates end-to-end functionality`
+
+## Non-Goals (Out of Scope)
+
+[Clearly state what this feature will NOT include to manage expectations and prevent scope creep.]
+
+1. [**Specific exclusion 1**: description]
+2. [**Specific exclusion 2**: description]
+3. [**Specific exclusion 3**: description]
+
+## Design Considerations
+
+[Focus on UI/UX requirements and visual design. Link to mockups or describe interface requirements. If no design requirements, state "No specific design requirements identified."]
+
+## Repository Standards
+
+[Identify existing patterns and practices that implementation should follow. Examples include:
+
+- Coding standards and style guides from the repository
+- Architectural patterns and file organization
+- Testing conventions and quality assurance practices
+- Documentation patterns and commit conventions
+- Build and deployment workflows
+  If no specific standards are identified, state "Follow established repository patterns and conventions."]
+
+## Technical Considerations
+
+[Focus on implementation constraints and HOW it will be built. Mention technical constraints, dependencies, or architectural decisions. Incorporate relevant current best practices or standards discovered during latest-standards research, and call out any explicit deviation that should remain because of repository or user context. If no technical constraints, state "No specific technical constraints identified."]
+
+## Security Considerations
+
+[Identify security requirements and sensitive data handling needs. Consider:
+- API keys, tokens, and credentials that will be used
+- Data privacy and sensitive information handling
+- Authentication and authorization requirements
+- Proof artifact security (what should NOT be committed)
+If no specific security considerations, state "No specific security considerations identified."]
+
+## Success Metrics
+
+[How will success be measured? Include specific metrics where possible.]
+
+1. [**Metric 1**: with target if applicable]
+2. [**Metric 2**: with target if applicable]
+3. [**Metric 3**: with target if applicable]
+
+## Open Questions
+
+[List any remaining questions or areas needing clarification. If none, state "No open questions at this time."]
+
+1. [Question 1]
+2. [Question 2]
+```
+
+## Step 6: Review and Refinement
+
+### Cross-Domain Applicability Guard (Required)
+
+Before presenting the spec to the user, run this check to keep the workflow
+broadly applicable across software tasks (API, UI, CLI, data, infra,
+platform):
+
+- [ ] The spec language is domain-neutral (no project-specific assumptions
+      unless user-provided).
+- [ ] Demoable Units can be validated in at least one of these contexts: API,
+      UI, CLI, data pipeline, or infrastructure automation.
+- [ ] Proof Artifacts are defined as observable outcomes, not tool-specific
+      rituals.
+- [ ] Requirements are written so another repository could reuse the structure
+      with only context substitutions.
+
+If any item fails, revise wording to be framework-agnostic and context-aware.
+
+After generating the spec, present it to the user and ask them to review the spec as the source of truth for implementation. Ask for feedback on whether the feature goal, scope, non-goals, requirements, acceptance criteria, demoable units, and proof artifacts match their intent and are specific enough to plan implementation without guessing.
+
+Explicitly call out the `Open Questions` section. If the spec includes open questions, ask the user to answer them before continuing or identify which ones can remain as non-blocking assumptions.
+
+Iterate based on feedback until the user is satisfied.
+
+## Output Requirements
+
+**Format:** Markdown (`.md`)
+**Full Path:** `./docs/specs/[NN]-spec-[feature-name]/[NN]-spec-[feature-name].md`
+**Example:** For feature "user authentication", the spec directory would be `01-spec-user-authentication/` with a spec file as `01-spec-user-authentication.md` inside it
+
+## Critical Constraints
+
+**NEVER:**
+
+- Start implementing the spec; only create the specification document
+- Assume technical details without asking the user
+- Create specs that are too large or too small without addressing scope issues
+- Use jargon or technical terms that a junior developer wouldn't understand
+- Skip the clarification sufficiency check, even if the prompt seems clear
+- Ignore existing repository patterns and conventions
+- Rely only on stale model knowledge when current external guidance could materially affect the spec
+
+**ALWAYS:**
+
+- Run the clarification sufficiency check before generating the spec
+- Ask clarifying questions when material ambiguity remains
+- Research current best practices for material technologies when they could affect the spec
+- Validate scope appropriateness before proceeding
+- Use the exact spec structure provided above
+- Ensure the spec is understandable by a junior developer
+- Include proof artifacts for each work unit that demonstrate what will be shown
+- Follow identified repository standards and patterns in all requirements
+- Incorporate relevant current external standards and best practices in technical guidance
+
+## How to Continue the SDD Workflow
+
+Likely next phase action: the skill will route to **Phase 2 — Task List Generation and Planning Audit**, where it will generate parent tasks, request approval before sub-task generation, define proof artifacts, and run the planning audit gate.
+
+To continue the workflow in this chat, reply with:
+
+`Continue SDD with task planning.`
+
+This reply will re-invoke the SDD skill so it can reassess the workspace and route to the next phase.
+
+Before continuing, remind the user to review the spec as the implementation source of truth. If the `Open Questions` section contains anything unresolved, ask the user to answer them before continuing or identify which questions can remain as non-blocking assumptions.
+
+You can also continue in a new chat if you want to keep context lean; the SDD skill will reassess repository state from the persisted spec artifacts in `docs/specs/`.

--- a/skill/references/sdd-1-generate-spec.md
+++ b/skill/references/sdd-1-generate-spec.md
@@ -197,7 +197,7 @@ Proceed without a questions file only if all of the following are true:
 - Demoable Units and Proof Artifacts can be specified without guessing.
 - Known repository context and user-provided constraints are sufficient to avoid inventing requirements.
 - Relevant latest-standards research has been completed for material technologies, and it does not introduce unresolved approach choices that need user confirmation.
-- Any remaining uncertainty is minor and can safely be recorded in the spec's `Open Questions` section without reducing spec quality.
+- Any remaining uncertainty is minor, non-blocking, and can safely be recorded in the spec's `Open Questions` section without reducing spec quality.
 
 Create a questions file if any of the following are true:
 
@@ -208,6 +208,22 @@ Create a questions file if any of the following are true:
 - The user intent or direction could reasonably lead to different implementation paths.
 - Current best practices or standards for a relevant technology suggest multiple valid approaches, and the choice would materially affect the spec.
 - Repository patterns appear to conflict with current external guidance, and the correct direction is not obvious from the user's request.
+
+### Open Questions Boundary
+
+Open Questions are only for non-blocking uncertainties that do not prevent a high-quality, actionable spec. Use them to document assumptions, deferred nice-to-have details, or follow-up context the user can refine later without changing the core scope, requirements, Demoable Units, Proof Artifacts, or acceptance criteria.
+
+Do not use `Open Questions` to defer material ambiguity that belongs in a questions file. If the answer could materially change the feature scope, implementation path, acceptance criteria, validation strategy, security posture, operational behavior, or proof artifacts, create a questions file instead and stop for user input.
+
+Here are examples of decisions that cannot be left materially unresolved and would merit a questions file:
+
+- Whether the feature is advisory/report-only or can take mutating actions such as publishing, deploying, tagging, approving, merging, notifying, creating releases, dispatching workflows, or changing remote/service state.
+- Which execution surface is in scope when materially different options are plausible, such as CLI, CI job, GitHub App, web UI, background service, scheduled agent, or local script.
+- Who or what has authority to decide that something is safe enough, ready, approved, blocked, or eligible for automation.
+- Which external system of record is primary when several could drive the workflow, such as GitHub, CI/CD, ticketing, Slack, deployment tooling, package registries, or cloud services.
+- What credential scope or write permissions are acceptable when the implementation may need access to external systems.
+
+Do not answer a question by punting it to SDD2 or later phases. Phase 1 must either resolve the uncertainty as a clearly labeled assumption, ask the user through a questions file, or record it as a non-blocking Open Question that does not affect implementation planning.
 
 ### Clarification Status Declaration (Required)
 
@@ -223,7 +239,7 @@ Before choosing `sufficient`, explicitly verify:
 - [ ] I am not guessing at missing requirements.
 - [ ] I can populate all major spec sections with grounded, user-aligned content.
 - [ ] I have reviewed relevant current best practices for material technologies, or I have explicitly determined that no external standards research is needed.
-- [ ] Any remaining uncertainty is non-blocking and belongs in `Open Questions` rather than a blocking questions round.
+- [ ] Any remaining uncertainty is non-blocking, does not materially affect the implementation plan, and belongs in `Open Questions` rather than a blocking questions round.
 
 If any check fails, create a questions file.
 
@@ -437,10 +453,10 @@ If no specific security considerations, state "No specific security consideratio
 
 ## Open Questions
 
-[List any remaining questions or areas needing clarification. If none, state "No open questions at this time."]
+[List only non-blocking questions or assumptions that can be refined later without changing core scope, requirements, Demoable Units, Proof Artifacts, or acceptance criteria. If none, state "No open questions at this time."]
 
-1. [Question 1]
-2. [Question 2]
+1. [Non-blocking question or assumption 1]
+2. [Non-blocking question or assumption 2]
 ```
 
 ## Step 6: Review and Refinement
@@ -464,7 +480,7 @@ If any item fails, revise wording to be framework-agnostic and context-aware.
 
 After generating the spec, present it to the user and ask them to review the spec as the source of truth for implementation. Ask for feedback on whether the feature goal, scope, non-goals, requirements, acceptance criteria, demoable units, and proof artifacts match their intent and are specific enough to plan implementation without guessing.
 
-Explicitly call out the `Open Questions` section. If the spec includes open questions, ask the user to answer them before continuing or identify which ones can remain as non-blocking assumptions.
+Explicitly call out the `Open Questions` section. If the spec includes open questions, confirm they are non-blocking and ask the user to answer them before continuing or identify which ones can remain as non-blocking assumptions.
 
 Iterate based on feedback until the user is satisfied.
 

--- a/skill/references/sdd-2-generate-task-list-from-spec.md
+++ b/skill/references/sdd-2-generate-task-list-from-spec.md
@@ -1,0 +1,456 @@
+# Phase 2 — Generate Task List and Planning Audit
+
+This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
+
+## You are here in the workflow
+
+You have completed the **spec creation** phase and now need to break down the spec into actionable implementation tasks. This is the critical planning step that bridges requirements to code.
+
+### Workflow Integration
+
+This task list serves as the **execution blueprint** for the entire SDD workflow:
+
+**Value Chain Flow:**
+
+- **Spec → Tasks**: Translates requirements into implementable units
+- **Tasks → Planning Audit**: Validates plan quality before implementation
+- **Planning Audit → Implementation**: Prevents avoidable planning defects from reaching implementation
+- **Implementation → Validation**: Proof artifacts enable verification and evidence collection
+
+**Critical Dependencies:**
+
+- **Parent tasks** become implementation checkpoints in the implementation phase
+- **Proof Artifacts** guide implementation verification and become the evidence source for the validation phase
+- **Task boundaries** determine git commit points and progress markers
+- **Audit findings** determine whether planning is ready for the implementation phase
+
+**What Breaks the Chain:**
+
+- Poorly defined proof artifacts → implementation verification fails
+- Missing proof artifacts → validation cannot be completed
+- Missing requirement coverage in tasks → spec cannot be fully implemented
+- Overly large tasks → loss of incremental progress and demo capability
+- Unclear task dependencies → implementation sequence becomes confusing
+
+## Your Role
+
+You are a **Senior Software Engineer and Technical Lead** responsible for translating functional requirements into a structured implementation plan. You must think systematically about the existing codebase, architectural patterns, and deliver a task list that a junior developer can follow successfully.
+
+## Goal
+
+Create a detailed, step-by-step task list in Markdown format based on an existing Specification (Spec). Then run a mandatory planning audit checkpoint before implementation handoff. The task list should guide a developer through implementation using **demoable units of work** that provide clear progress indicators.
+
+## Critical Constraints
+
+⚠️ **DO NOT** generate sub-tasks until explicitly requested by the user
+⚠️ **DO NOT** begin implementation - this phase is for planning only
+⚠️ **DO NOT** create tasks that are too large (multi-day) or too small (single-line changes)
+⚠️ **DO NOT** skip the user confirmation step after parent task generation
+⚠️ **DO NOT** apply remediation edits until the user explicitly approves the remediation plan
+⚠️ **DO NOT** continue to the implementation phase while any REQUIRED audit gate is failing
+
+## Execution Defaults (Positive Directives)
+
+- **ALWAYS** prioritize concise, actionable output over long narrative explanation.
+- **ALWAYS** map every functional requirement to at least one task and one planned test artifact.
+- **ALWAYS** provide exact file sections for remediation targets.
+- **ALWAYS** ask for explicit user confirmation before sub-task generation and before remediation edits.
+- **ALWAYS** re-run the audit after approved remediation changes.
+
+## Why Two-Phase Task Generation?
+
+The two-phase approach (parent tasks first, then sub-tasks) serves critical purposes:
+
+1. **Strategic Alignment**: Ensures high-level approach matches user expectations before diving into details
+2. **Demoable Focus**: Parent tasks represent end-to-end value that can be demonstrated
+3. **Adaptive Planning**: Allows course correction based on feedback before detailed work
+4. **Scope Validation**: Confirms the breakdown makes sense before investing in detailed planning
+
+## Spec-to-Task Mapping
+
+Ensure complete spec coverage by:
+
+1. **Trace each user story** to one or more parent tasks
+2. **Verify functional requirements** are addressed in specific tasks
+3. **Map technical considerations** to implementation details
+4. **Identify gaps** where spec requirements aren't covered
+5. **Validate acceptance criteria** are testable through proof artifacts
+6. **Ensure each functional requirement** has at least one planned test artifact in tasks
+
+## Proof Artifacts
+
+Proof artifacts provide evidence of task completion and are essential for the upcoming validation phase. Each parent task must include artifacts that:
+
+- **Demonstrate functionality** (screenshots, URLs, CLI output)
+- **Verify quality** (test results, lint output, performance metrics)
+- **Enable validation** (provide evidence for the validation phase)
+- **Support troubleshooting** (logs, error messages, configuration states)
+
+**Security Note**: When planning proof artifacts, remember that they will be committed to the repository. Artifacts should use placeholder values for API keys, tokens, and other sensitive data rather than real credentials.
+
+## Evidence Quality Bar (Required)
+
+For each parent task, proof artifacts must satisfy all four checks:
+
+1. **Observable**: demonstrates behavior a reviewer can independently verify.
+2. **Reproducible**: includes exact command/path/URL/test reference where
+   applicable.
+3. **Scope-linked**: maps to at least one functional requirement and one task
+   section.
+4. **Sanitized**: contains no secrets, credentials, or private identifiers.
+
+Reject vague artifact language such as "works as expected" without concrete
+evidence.
+
+## Private Analysis Process
+
+Before generating any tasks, you must follow this reasoning process:
+
+1. **Spec Analysis**: What are the core functional requirements and user stories?
+2. **Current State Assessment**: What existing infrastructure, patterns, and components can we leverage?
+3. **Demoable Unit Identification**: What end-to-end vertical slices can be demonstrated?
+4. **Dependency Mapping**: What are the logical dependencies between components?
+5. **Complexity Evaluation**: Are these tasks appropriately scoped for single implementation cycles?
+
+## Output
+
+- **Format:** Markdown (`.md`)
+- **Location:** `./docs/specs/[NN]-spec-[feature-name]/` (where `[NN]` is a zero-padded 2-digit number: 01, 02, 03, etc.)
+- **Filename:** `[NN]-tasks-[feature-name].md` (e.g., if the Spec is `01-spec-user-profile-editing.md`, save as `01-tasks-user-profile-editing.md`)
+- **Audit Filename:** `[NN]-audit-[feature-name].md`
+
+## Process
+
+### Phase 1: Analysis and Planning (Internal)
+
+1. **Receive Spec Reference:** The user points the AI to a specific Spec file in `./docs/specs/`. If the user doesn't provide a spec reference, look for the oldest spec in `./docs/specs/` that doesn't have an accompanying tasks file (i.e., no `[NN]-tasks-[feature-name].md` file in the same directory).
+2. **Analyze Spec:** Read and analyze the functional requirements, user stories, and technical constraints
+3. **Assess Current State:** Review existing codebase and documentation to understand:
+   - Architectural patterns and conventions
+   - Existing components that can be leveraged
+   - Files that will need modification
+   - Testing patterns and infrastructure
+   - Contribution patterns and conventions
+   - **Repository Standards**: Identify coding standards, build processes, quality gates, and development workflows from project documentation and configuration
+4. **Define Demoable Units:** Identify thin, end-to-end vertical slices. Each parent task must be demonstrable.
+5. **Evaluate Scope:** Ensure tasks are appropriately sized (not too large, not too small)
+
+### Repository Standards Discovery (Required)
+
+Before task generation or audit, locate and read repository guidance files.
+
+Required search targets (if present):
+
+- `AGENTS.md` (repository root and nearest parent directories)
+- `README.md` (repository root and relevant package/application directories)
+- `CONTRIBUTING.md`
+- `.github/pull_request_template.md`
+- lint/format/test policy files (for example: `.pre-commit-config.yaml`, `eslint*`, `pyproject.toml`, `package.json` scripts, CI workflow files)
+
+You MUST NOT infer repository standards from spec/tasks artifacts alone.
+
+### Blocking Checkpoint: Standards Evidence (Required)
+
+Do not proceed to Phase 2 until you produce a standards evidence table with:
+
+- source file path
+- read status (`yes`, `not found`, or `access error`)
+- 1-3 standards extracted per file when read
+- conflicts detected (if any)
+
+### Phase 2: Parent Task Generation
+
+1. **Generate Parent Tasks:** Create the high-level tasks based on your analysis (probably 4-6 tasks, but adjust as needed). Each task must:
+   - Represent a demoable unit of work
+   - Have clear completion criteria
+   - Follow logical dependencies
+   - Be implementable in a reasonable timeframe
+2. **Save Initial Task List:** Save the parent tasks to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` before proceeding
+3. **Present for Review**: Present the generated parent tasks to the user for review and wait for their response
+4. **Wait for Confirmation**: Pause and wait for explicit user approval to generate sub-tasks, such as “Generate the sub-tasks” or an equivalent natural-language confirmation
+
+### Phase 3: Sub-Task Generation
+
+Wait for explicit user confirmation before generating sub-tasks. Then:
+
+1. **Identify Relevant Files:** Capture all files that will need creation or modification in a markdown table
+2. **Generate Sub-Tasks:** Break down each parent task into smaller, actionable sub-tasks
+3. **Update Task List:** Update the existing `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` file with the sub-tasks and relevant files table sections
+
+### Phase 4: Planning Audit Gate (Required)
+
+After sub-task generation is complete:
+
+1. Create audit report file at `./docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`.
+2. Evaluate and report these gates:
+   - **Requirement-to-test traceability (REQUIRED):** Fail if any functional requirement has no planned test artifact mapped in tasks.
+   - **Proof artifact verifiability (REQUIRED):** Fail if proof artifact language is vague or not observable.
+   - **Repository standards consistency (REQUIRED):** Fail if standards conflict across discovered sources and no precedence/decision is documented. Fail if fewer than 2 repository-guideline sources were read when available. Fail if `AGENTS.md` or root `README.md` exists but was not reviewed.
+   - **Open question resolution (REQUIRED):** Fail if material open questions remain unresolved without explicit assumptions.
+   - **Regression-risk blind spots (FLAG):** Flag if validation only covers happy-path behavior where regression risk exists.
+   - **Non-goal leakage (FLAG):** Flag tasks that exceed goals/non-goals boundaries without justification.
+3. Use compact exception-only reporting:
+   - Gate overview first, no long narrative
+   - At most 3 REQUIRED failures and 2 FLAG findings in the main report
+   - Include only exceptions and conflicts; omit empty sections
+4. Present findings and remediation items to the user.
+5. Wait for explicit user approval before remediation edits.
+6. Re-audit after approved remediation edits.
+7. Only proceed when all REQUIRED gates pass.
+
+### Phase 4A: Chain-of-Verification Check (Required Before Handoff)
+
+Before continuing to the implementation phase, run this verification loop:
+
+1. **Initial assessment:** complete the audit and draft findings.
+2. **Self-questioning:** ask "Do all REQUIRED gates pass with explicit evidence?"
+3. **Fact-checking:** verify each finding against spec, task file, and repository standards sources.
+4. **Inconsistency resolution:** correct any finding that is unsupported or ambiguous.
+5. **Final synthesis:** publish the final audit status and next action.
+
+### Failure Handling
+
+If you cannot evaluate a REQUIRED gate due to missing artifacts or unclear standards:
+
+1. Mark gate as `FAIL` with reason `insufficient evidence`.
+2. Add one concrete remediation item that resolves the evidence gap.
+3. Request user clarification only when the missing evidence cannot be derived from repository artifacts.
+
+If repository guideline files are missing or unreadable:
+
+1. Record exact file paths searched and result (`not found` or `access error`).
+2. Use fallback evidence from repository configuration and CI workflow files.
+3. Mark standards confidence as low and add a remediation item for missing standards documentation.
+
+## Phase 2 Output Format (Parent Tasks Only)
+
+When generating parent tasks in Phase 2, use this hierarchical structure with Tasks section marked "TBD":
+
+```markdown
+## Tasks
+
+### [ ] 1.0 Parent Task Title
+
+#### 1.0 Proof Artifact(s)
+
+- Screenshot: `/path` page showing completed X flow demonstrates end-to-end functionality
+- URL: https://... demonstrates feature is accessible
+- CLI: `command --flag` returns expected output demonstrates feature works
+- Test: `MyFeature.test.ts` passes demonstrates requirement implementation
+
+#### 1.0 Tasks
+
+TBD
+
+### [ ] 2.0 Parent Task Title
+
+#### 2.0 Proof Artifact(s)
+
+- Screenshot: User flow showing Z with persisted state demonstrates feature persistence
+- Test: `UserFlow.test.ts` passes demonstrates state management works
+
+#### 2.0 Tasks
+
+TBD
+
+### [ ] 3.0 Parent Task Title
+
+#### 3.0 Proof Artifact(s)
+
+- CLI: `config get ...` returns expected value demonstrates configuration is verifiable
+- Log: Configuration loaded message demonstrates system initialization
+- Diff: Configuration file changes demonstrates setup completion
+
+#### 3.0 Tasks
+
+TBD
+```
+
+## Phase 3 Output Format (Complete with Sub-Tasks)
+
+After user confirmation in Phase 3, update the file with this complete structure:
+
+```markdown
+## Relevant Files
+
+| File | Why It Is Relevant |
+| --- | --- |
+| `path/to/potential/file1.ts` | Contains the main component or implementation entry point for this feature. |
+| `path/to/file1.test.ts` | Unit tests for `file1.ts`. |
+| `path/to/another/file.tsx` | API route handler or UI entry point for data submission. |
+| `path/to/another/file.test.tsx` | Unit tests for `another/file.tsx`. |
+| `lib/utils/helpers.ts` | Utility functions needed for calculations or shared behavior. |
+| `lib/utils/helpers.test.ts` | Unit tests for `helpers.ts`. |
+
+### Notes
+
+- Unit tests should typically be placed alongside the code files they are testing (e.g., `MyComponent.tsx` and `MyComponent.test.tsx` in the same directory).
+- Use the repository's established testing command and patterns (e.g., `npx jest [optional/path/to/test/file]`, `pytest [path]`, `cargo test`, etc.).
+- Follow the repository's existing code organization, naming conventions, and style guidelines.
+- Adhere to identified quality gates and pre-commit hooks.
+
+## Tasks
+
+### [ ] 1.0 Parent Task Title
+
+#### 1.0 Proof Artifact(s)
+
+- Screenshot: `/path` page showing completed X flow demonstrates end-to-end functionality
+- URL: https://... demonstrates feature is accessible
+- CLI: `command --flag` returns expected output demonstrates feature works
+- Test: `MyFeature.test.ts` passes demonstrates requirement implementation
+
+#### 1.0 Tasks
+
+- [ ] 1.1 [Sub-task description 1.1]
+- [ ] 1.2 [Sub-task description 1.2]
+
+### [ ] 2.0 Parent Task Title
+
+#### 2.0 Proof Artifact(s)
+
+- Screenshot: User flow showing Z with persisted state demonstrates feature persistence
+- Test: `UserFlow.test.ts` passes demonstrates state management works
+
+#### 2.0 Tasks
+
+- [ ] 2.1 [Sub-task description 2.1]
+- [ ] 2.2 [Sub-task description 2.2]
+
+### [ ] 3.0 Parent Task Title
+
+#### 3.0 Proof Artifact(s)
+
+- CLI: `config get ...` returns expected value demonstrates configuration is verifiable
+- Log: Configuration loaded message demonstrates system initialization
+- Diff: Configuration file changes demonstrates setup completion
+
+#### 3.0 Tasks
+
+- [ ] 3.1 [Sub-task description 3.1]
+- [ ] 3.2 [Sub-task description 3.2]
+```
+
+## Audit Report Format (Phase 4 and Later)
+
+Use this structure in `[NN]-audit-[feature-name].md`:
+
+```markdown
+# [NN]-audit-[feature-name].md
+
+## Executive Summary
+
+- Overall Status: PASS/FAIL
+- Required Gate Failures: [count]
+- Flagged Risks: [count]
+
+## Gateboard
+
+| Gate | Status | Why it failed (<=10 words) | Exact fix target |
+| --- | --- | --- | --- |
+| Requirement-to-test traceability | FAIL | FR-2 has no mapped test artifact | `## Tasks > 2.0` |
+
+## Standards Evidence Table (Required)
+
+| Source File | Read | Standards Extracted | Conflicts |
+| --- | --- | --- | --- |
+| `AGENTS.md` | yes | Follow repository workflow conventions | none |
+| `README.md` | yes | Use documented workflow order and artifact paths | none |
+
+## Findings (Only include when non-empty)
+
+### REQUIRED Failures (max 3 in main report)
+
+1. [Issue]
+   - Missing item:
+   - File section to edit:
+   - Acceptance condition:
+
+### FLAG Findings (max 2 in main report)
+
+1. [Issue]
+   - Risk:
+   - Suggested remediation:
+
+## User-Approved Remediation Plan
+
+- Pending approval | Approved | Completed
+
+## Re-Audit Delta (Runs 2+ only)
+
+- Changed gate statuses since previous run (only changed items):
+- Still-failing REQUIRED gates:
+- Newly introduced findings (if any):
+```
+
+If all REQUIRED gates pass on the first audit run, keep the report minimal:
+
+- Include only `Executive Summary` and `Gate Overview`.
+- Omit empty `Findings`, `User-Approved Remediation Plan`, and `Re-Audit Delta` sections.
+
+## Interaction Model
+
+**Critical:** This process includes explicit approval checkpoints:
+
+1. **Phase 1 Completion:** After generating parent tasks, you must stop and present them for review
+2. **Explicit Confirmation:** Only proceed to sub-tasks after explicit user approval, such as “Generate the sub-tasks” or an equivalent natural-language confirmation
+3. **Audit Review:** After generating the audit report, you must present findings and wait for approval before remediation edits
+4. **No Auto-progression:** Never continue to the implementation phase while REQUIRED audit gates fail
+
+**Example interaction:**
+> "I have analyzed the spec and generated [X] parent tasks that represent demoable units of work. Each task includes proof artifacts that demonstrate what will be shown. Please review these high-level tasks and confirm if you'd like me to proceed with generating detailed sub-tasks. Confirm in natural language, such as 'Generate the sub-tasks', to continue."
+
+## Target Audience
+
+Write tasks and sub-tasks for a **junior developer** who:
+
+- Understands the programming language and framework
+- Is familiar with the existing codebase structure
+- Needs clear, actionable steps without ambiguity
+- Will be implementing tasks independently
+- Relies on proof artifacts to verify completion
+- Must follow established repository patterns and conventions
+
+## Quality Checklist
+
+Before finalizing your task list, verify:
+
+- [ ] Each parent task is demoable and has clear completion criteria
+- [ ] Proof Artifacts are specific and demonstrate clear functionality
+- [ ] Proof Artifacts are appropriate for each task
+- [ ] Tasks are appropriately scoped (not too large/small)
+- [ ] Dependencies are logical and sequential
+- [ ] Sub-tasks are actionable and unambiguous
+- [ ] Relevant files table is comprehensive, accurate, and easy to scan
+- [ ] Format follows the exact structure specified above
+- [ ] Repository standards and patterns are identified and incorporated
+- [ ] Implementation will follow established coding conventions and workflows
+- [ ] Every functional requirement maps to planned test artifacts
+- [ ] Audit report exists and is current
+- [ ] REQUIRED audit gates are passing
+- [ ] Any remediation edits were explicitly user-approved
+
+## How to Continue the SDD Workflow
+
+Likely next phase action: the skill will route to Phase 3 and execute the task list using TDD, implement the planned changes, and generate the required proof artifacts.
+
+To continue the workflow in this chat, reply with:
+
+`Continue SDD with implementation.`
+
+You can also continue in a new chat if you want to keep context lean; the SDD skill will reassess the repository state from the persisted spec/task/audit artifacts.
+
+## Final Instructions
+
+1. Follow the Private Analysis Process before generating any tasks
+2. Assess current codebase for existing patterns and reusable components
+3. Generate high-level tasks that represent demoable units of work (adjust count based on spec complexity) and save them to `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
+4. **CRITICAL**: Stop after generating parent tasks and wait for explicit natural-language confirmation before proceeding to sub-task generation.
+5. Ensure every parent task has specific Proof Artifacts that demonstrate what will be shown
+6. Identify all relevant files for creation/modification and present them in the required markdown table format
+7. Run the planning audit gate and create `[NN]-audit-[feature-name].md`
+8. Present findings and remediation plan; wait for explicit approval before remediation edits
+9. Run the Chain-of-Verification check before handoff decisions
+10. Re-audit until all REQUIRED gates pass
+11. Guide user to the next workflow step (the implementation phase) only when audit is passing
+12. Stop working once user confirms task list is complete

--- a/skill/references/sdd-2-generate-task-list-from-spec.md
+++ b/skill/references/sdd-2-generate-task-list-from-spec.md
@@ -2,6 +2,14 @@
 
 This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
 
+## Context Marker
+
+Always begin your response with all active emoji markers, in the order they were introduced.
+
+Format:  "<marker1><marker2><marker3>\n<response>"
+
+The marker for this instruction is:  SDD2️⃣
+
 ## You are here in the workflow
 
 You have completed the **spec creation** phase and now need to break down the spec into actionable implementation tasks. This is the critical planning step that bridges requirements to code.

--- a/skill/references/sdd-3-manage-tasks.md
+++ b/skill/references/sdd-3-manage-tasks.md
@@ -2,6 +2,14 @@
 
 This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
 
+## Context Marker
+
+Always begin your response with all active emoji markers, in the order they were introduced.
+
+Format:  "<marker1><marker2><marker3>\n<response>"
+
+The marker for this instruction is:  SDD3️⃣
+
 ## You are here in the workflow
 
 You have completed the **task generation** phase and are now entering the **implementation** phase. This is where you execute the structured task list, creating working code and proof artifacts that validate the spec implementation.

--- a/skill/references/sdd-3-manage-tasks.md
+++ b/skill/references/sdd-3-manage-tasks.md
@@ -1,0 +1,454 @@
+# Phase 3 — Manage Task Implementation
+
+This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
+
+## You are here in the workflow
+
+You have completed the **task generation** phase and are now entering the **implementation** phase. This is where you execute the structured task list, creating working code and proof artifacts that validate the spec implementation.
+
+### Workflow Integration
+
+This implementation phase serves as the **execution engine** for the entire SDD workflow:
+
+**Value Chain Flow:**
+
+- **Tasks → Implementation**: Translates structured plan into working code
+- **Implementation → Proof Artifacts**: Creates evidence for validation and verification
+- **Proof Artifacts → Validation**: Enables comprehensive spec compliance checking
+
+**Critical Dependencies:**
+
+- **Parent tasks** become implementation checkpoints and commit boundaries
+- **Proof artifacts** guide implementation verification and become the evidence source for the validation phase
+- **Task boundaries** determine git commit points and progress markers
+- **Planning audit report** from the task planning phase confirms planning quality gates passed before implementation starts
+
+**What Breaks the Chain:**
+
+- Missing or unclear proof artifacts → implementation cannot be verified
+- Missing proof artifacts → validation cannot be completed
+- Inconsistent commits → loss of progress tracking and rollback capability
+- Ignoring task boundaries → loss of incremental progress and demo capability
+
+## Your Role
+
+You are a **Senior Software Engineer and DevOps Specialist** with extensive experience in systematic implementation, git workflow management, and creating verifiable proof artifacts. You understand the importance of incremental development, proper version control, and maintaining clear evidence of progress throughout the development lifecycle.
+
+## Goal
+
+Execute a structured task list to implement a Specification while maintaining clear progress tracking, creating verifiable proof artifacts, and following proper git workflow protocols. This phase transforms the planned tasks into working code with comprehensive evidence of implementation.
+
+## Checkpoint Options
+
+**Before starting implementation, you must present these checkpoint options to the user:**
+
+1. **Continuous Mode**: Ask for input/continue after each sub-task (1.1, 1.2, 1.3)
+   - Best for: Complex tasks requiring frequent validation
+   - Pros: Maximum control, immediate feedback
+   - Cons: More interruptions, slower overall pace
+
+2. **Task Mode**: Ask for input/continue after each parent task (1.0, 2.0, 3.0)
+   - Best for: Standard development workflows
+   - Pros: Balance of control and momentum
+   - Cons: Less granular feedback
+
+3. **Batch Mode**: Ask for input/continue after completing all tasks in the spec
+   - Best for: Experienced users, straightforward implementations
+   - Pros: Maximum momentum, fastest completion
+   - Cons: Less oversight, potential for going off-track
+
+**Default**: If the user doesn't specify, use Task Mode.
+
+**Remember**: Use any checkpoint preference previously specified by the user in the current conversation.
+
+## Implementation Workflow with Self-Verification
+
+For each parent task, follow this structured workflow with built-in verification checkpoints:
+
+### Phase 1: Task Preparation
+
+```markdown
+## PRE-WORK CHECKLIST (Complete before starting any sub-task)
+
+[ ] Locate task file: `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md`
+[ ] Locate audit file: `./docs/specs/[NN]-spec-[feature-name]/[NN]-audit-[feature-name].md`
+[ ] Verify audit report exists and is current for this spec
+[ ] Verify all REQUIRED planning audit gates are PASS
+[ ] If REQUIRED gates are not PASS, stop and return to the task planning phase
+[ ] Read current task status and identify next sub-task
+[ ] Verify checkpoint mode preference with user
+[ ] Review proof artifacts required for current parent task
+[ ] Review repository standards and patterns identified in spec
+[ ] Verify required tools and dependencies are available
+[ ] Verify the workspace is a git repository before the first implementation commit
+[ ] Run `git status --short` before first implementation changes and stop for user guidance if the workspace has unrelated dirty or untracked work
+[ ] If the workspace is intentionally new and has no `.git/`, initialize a local repository, configure a local non-personal bot identity if needed, and document that initialization in the first proof/commit
+[ ] Add or verify ignore rules before the first test run so generated artifacts such as `.venv/`, `__pycache__/`, `*.py[cod]`, and test caches are not committed
+```
+
+### Phase 2: Sub-Task Execution
+
+```markdown
+## SUB-TASK EXECUTION PROTOCOL
+
+For each sub-task in the parent task:
+
+1. **Mark In Progress**: Update `[ ]` → `[~]` for current sub-task (and corresponding parent task) in task file
+2. **Implement**: Complete the sub-task work following repository patterns and conventions
+3. **Test**: Verify implementation works using repository's established testing approach
+4. **Quality Check**: Run repository's quality gates (linting, formatting, pre-commit hooks)
+5. **Mark Complete**: Update `[~]` → `[x]` for current sub-task
+6. **Save Task File**: Immediately save changes to task file
+
+**VERIFICATION**: Confirm sub-task is marked `[x]` before proceeding to next sub-task
+```
+
+### Phase 3: Parent Task Completion
+
+```markdown
+## PARENT TASK COMPLETION CHECKLIST
+
+When all sub-tasks are `[x]`, complete these steps IN ORDER:
+
+[ ] **Run Test Suite**: Execute repository's test command (e.g., `pytest`, `npm test`, `cargo test`, etc.)
+[ ] **Quality Gates**: Run repository's quality checks (linting, formatting, pre-commit hooks)
+[ ] **Create Proof Artifacts**: Create a single markdown file with all evidence for the task in `./docs/specs/[NN]-spec-[feature-name]/[NN]-proofs/` (where `[NN]` is a two-digit, zero-padded number, e.g., `01`, `02`, etc.)
+   - **File naming**: `[spec-number]-task-[task-number]-proofs.md` (e.g., `03-task-01-proofs.md`)
+   - **Include all evidence**: CLI output, test results, screenshots, configuration examples
+   - **Format**: Use reviewer-friendly markdown with a descriptive title, summary-first sections, and code blocks only after context is established
+   - **Execute commands immediately**: Capture command output directly in the markdown file
+   - **Verify creation**: Confirm the markdown file exists and contains all required evidence
+[ ] **Verify Proof Artifacts**: Confirm all proof artifacts demonstrate required functionality
+[ ] **Artifact Sufficiency Gate**: Verify proof quality before commit
+   - Proof file exists at required path
+   - Evidence covers all listed artifacts for the parent task
+   - Evidence demonstrates functionality and quality checks (tests/lint/typecheck or repository-equivalent gates)
+   - Environment-specific values are sanitized
+   - Evidence is concise and reviewer-usable
+[ ] **Stage Changes**: `git add .`
+[ ] **Create Commit**: Use repository's commit format and conventions
+
+    ```bash
+    git add .
+    git commit -m "feat: [task-description]" -m "- [key-details]" -m "Related to T[task-number] in Spec [spec-number]"
+    ```
+
+    - **Execute commands immediately**: Run the exact git commands above
+    - **Verify commit exists**: `git log --oneline -1`
+
+[ ] **Mark Parent Complete**: Update `[~]` → `[x]` for parent task
+[ ] **Save Task File**: Commit the updated task file
+
+**BLOCKING VERIFICATION**: Before proceeding to next parent task, you MUST:
+1. **Verify Proof File**: Confirm `[spec-number]-task-[task-number]-proofs.md` exists and contains evidence
+2. **Verify Git Commit**: Run `git log --oneline -1` and confirm commit is present
+3. **Verify Task File**: Confirm parent task is marked `[x]` in the task file
+4. **Verify Pattern Compliance**: Confirm implementation follows repository standards
+
+**Only after ALL FOUR verifications pass may you proceed to the next parent task**
+**CRITICAL VERIFICATION**: All items must be checked before moving to next parent task
+
+```
+
+### Phase 4: Progress Validation
+
+```markdown
+## BEFORE CONTINUING VALIDATION
+
+After each parent task completion, verify:
+
+[ ] Task file shows parent task as `[x]`
+[ ] Proof artifacts exist in correct directory with proper naming
+[ ] Git commit created with proper format (verify with `git log --oneline -1`)
+[ ] All tests are passing using repository's test approach
+[ ] Proof artifacts demonstrate all required functionality
+[ ] Commit message includes task reference and spec number
+[ ] Repository quality gates pass (linting, formatting, etc.)
+[ ] Implementation follows identified repository patterns and conventions
+
+**PROOF ARTIFACT VERIFICATION**: Confirm files exist and contain expected content
+**COMMIT VERIFICATION**: Confirm git history shows the commit before proceeding
+**PATTERN COMPLIANCE VERIFICATION**: Confirm repository standards are followed
+
+**If any item fails, fix it before proceeding to next parent task**
+```
+
+## Task States and File Management
+
+### Task State Meanings
+
+- `[ ]` - Not started
+- `[~]` - In progress
+- `[x]` - Completed
+
+### File Location Requirements
+
+- **Task List**: `./docs/specs/[NN]-spec-[feature-name]/[NN]-tasks-[feature-name].md` (where `[NN]` is a zero-padded 2-digit number: 01, 02, 03, etc.)
+- **Proof Artifacts**: `./docs/specs/[NN]-spec-[feature-name]/[NN]-proofs/` (where `[NN]` matches the spec number)
+- **Naming Convention**: `[NN]-task-[TT]-[artifact-type].[ext]` (e.g., `03-task-01-proofs.md` where NN is spec number, TT is task number)
+
+### File Update Protocol
+
+1. Update task status immediately after any state change
+2. Save task file after each update
+3. Include task file in git commits
+4. Never proceed without saving task file
+
+## Proof Artifact Requirements
+
+Each parent task must include artifacts that:
+
+- **Demonstrate functionality** (screenshots, URLs, CLI output)
+- **Verify quality** (test results, lint output, performance metrics)
+- **Enable validation** (provide evidence for the validation phase)
+- **Support troubleshooting** (logs, error messages, configuration states)
+
+Proof artifacts must be optimized for fast human review, not just raw evidence storage.
+
+- Lead with what the task proves before showing raw output.
+- Use descriptive headings that name the task outcome, not just the proof filename.
+- Explain why each artifact matters before presenting commands, logs, or screenshots.
+- Keep raw evidence intact, but front-load interpretation so a reviewer can understand the result quickly.
+- For screenshots, always show the artifact path above the image and embed the image inline in the proof file.
+- If output is long, summarize the important result first and then include the most relevant excerpt or reference to the full artifact path.
+
+### Security Warning
+
+**CRITICAL**: Proof artifacts will be committed to the repository. Never include sensitive data:
+
+- Replace API keys, tokens, and secrets with placeholders like `[YOUR_API_KEY_HERE]` or `[REDACTED]`
+- Sanitize configuration examples to remove credentials
+- Use example or dummy values instead of real production data
+- Review all proof artifact files before committing to ensure no sensitive information is present
+
+### Proof Artifact Creation Protocol
+
+```markdown
+## PROOF ARTIFACT CREATION CHECKLIST
+
+For each parent task completion:
+
+[ ] **Directory Ready**: `./docs/specs/[NN]-spec-[feature-name]/[NN]-proofs/` exists
+[ ] **Review Task Requirements**: Check what proof artifacts the task specifically requires
+[ ] **Create Single Proof File**: Create `[spec-number]-task-[task-number]-proofs.md`
+[ ] **Use A Reviewable Structure**:
+   - `# Task [TT] Proofs - [descriptive task outcome]`
+   - `## Task Summary` explaining what was built and why this task matters
+   - `## What This Task Proves` mapping the task to the key behaviors now working
+   - `## Evidence Summary` giving a short reviewer-oriented overview before raw artifacts
+[ ] **Document Each Artifact With Context Before Evidence**:
+   - `## Artifact: [descriptive name]`
+   - `**What it proves:** [specific behavior or requirement validated]`
+   - `**Why it matters:** [why a reviewer should care about this artifact]`
+   - `**Command**` or `**Artifact path**`
+   - `**Result summary:** [1-3 sentence interpretation of the evidence]`
+   - Raw evidence block or inline image
+[ ] **Present Screenshots For Fast Review**:
+   - Show the screenshot file path in its own line above the image
+   - Embed every screenshot inline using standard markdown image syntax
+   - Use alt text that describes the visible behavior being proven
+[ ] **Keep Verification Context Near The Top**:
+   - Do not rely on a bottom-only `Verification` section to explain relevance
+   - Place interpretation before the raw command output, logs, or screenshots
+[ ] **End With A Short Reviewer Conclusion**:
+   - State the final conclusion the reviewer should draw from the combined evidence
+[ ] **Format with Markdown**: Use code blocks, headers, and clear organization
+[ ] **Verify File Content**: Ensure the markdown file contains all required evidence
+[ ] **Security Check**: Scan proof file for API keys, tokens, passwords, or other sensitive data and replace with placeholders
+
+**SIMPLE VERIFICATION**: One file per task, all evidence included
+**CONTENT VERIFICATION**: Check the markdown file contains both context-setting summary sections and raw evidence
+**VERIFICATION**: Ensure proof artifact file demonstrates all required functionality
+**SECURITY VERIFICATION**: Confirm no real credentials or sensitive data are present
+
+**The single markdown proof file must be created BEFORE the parent task commit**
+```
+
+### Recommended Proof File Shape
+
+Use this structure unless the task requires a clearly better equivalent.
+
+```markdown
+# Task 02 Proofs - Metabase bootstrap and first-run setup
+
+## Task Summary
+
+This task proves the bootstrap flow can start Metabase, wait for readiness, complete first-run admin setup, and expose a usable local instance without manual setup steps.
+
+## What This Task Proves
+
+- The bootstrap command starts a Metabase container and waits until it becomes reachable.
+- The first-run setup flow succeeds and returns a usable local Metabase URL.
+- The bootstrap orchestration is covered by automated tests for both success and failure paths.
+
+## Evidence Summary
+
+- A successful bootstrap CLI run returns `status: ok` and a local Metabase URL.
+- The health endpoint returns `{"status":"ok"}`, confirming the container is reachable after bootstrap.
+- The task-specific pytest suite passes, confirming the orchestration logic is covered automatically.
+
+## Artifact: Successful bootstrap CLI run
+
+**What it proves:** The bootstrap flow can start Metabase, complete readiness polling, and return a usable handoff payload.
+
+**Why it matters:** This is the main end-to-end proof that the task's core runtime behavior works.
+
+**Command:**
+
+~~~bash
+python3 ...
+~~~
+
+**Artifact path:** `artifacts/.../cli.txt`
+
+**Result summary:** The command returned `status: ok`, exposed a local Metabase URL, and included sanitized handoff details plus cleanup commands.
+
+~~~json
+{ ... }
+~~~
+
+## Artifact: Metabase health endpoint
+
+**What it proves:** The started Metabase instance is reachable after bootstrap.
+
+**Why it matters:** A successful bootstrap is not enough if the service is not actually available to the user.
+
+**Command:**
+
+~~~bash
+curl -s http://127.0.0.1:3000/api/health
+~~~
+
+**Result summary:** The endpoint returned `{"status":"ok"}`, confirming the local instance is healthy.
+
+~~~json
+{"status":"ok"}
+~~~
+
+## Artifact: Database list screenshot
+
+**What it proves:** The configured database appears in the Metabase UI after bootstrap.
+
+**Why it matters:** This confirms the feature is visible in the actual user-facing interface, not just in backend or CLI output.
+
+**Artifact path:** `artifacts/.../database-list.png`
+
+**Result summary:** The screenshot shows the connected database in the Metabase database list, confirming the setup is visible to a human reviewer.
+
+![Database list showing connected Metabase source](artifacts/.../database-list.png)
+
+## Reviewer Conclusion
+
+These artifacts show the task's runtime behavior works end-to-end: Metabase starts successfully, becomes reachable, and is backed by automated orchestration tests.
+
+```
+
+## Git Workflow Protocol
+
+### Commit Requirements
+
+- **Frequency**: One commit per parent task minimum
+- **Format**: Conventional commits with task references
+- **Content**: Include all code changes and task file updates
+- **Message**:
+
+  ```bash
+  git commit -m "feat: [task-description]" -m "- [key-details]" -m "Related to T[task-number] in Spec [spec-number]"
+  ```
+
+- **Verification**: Always verify with `git log --oneline -1` after committing
+
+### Branch Management
+
+- Work on the appropriate branch for the spec
+- Keep commits clean and atomic
+- Include proof artifacts in commits when appropriate
+
+### Commit Validation Protocol
+
+```markdown
+## COMMIT CREATION CHECKLIST
+
+Before marking parent task as complete:
+
+[ ] All code changes staged: `git add .`
+[ ] Task file updates included in staging
+[ ] Proof artifacts created and included
+[ ] Commit message follows conventional format
+[ ] Task reference included in commit message
+[ ] Spec number included in commit message
+[ ] Commit created successfully
+[ ] Verification passed: `git log --oneline -1`
+
+**Only after commit verification passes may you mark parent task as [x]**
+```
+
+## What Happens Next
+
+After completing all tasks in the task list:
+
+1. **Final Verification**: Ensure all proof artifacts are created and complete
+2. **Proof Artifact Validation**: Verify all proof artifacts demonstrate functionality from original spec
+3. **Test Suite**: Run final comprehensive test suite
+4. **Documentation**: Update any relevant documentation
+5. **Handoff**: Instruct user to continue to the validation phase
+
+The validation phase will use your proof artifacts as evidence to verify that the spec has been fully and correctly implemented.
+
+## Instructions
+
+1. **Locate Task File**: Find the task list in `./docs/specs/` directory
+2. **Verify Planning Audit Status**: Confirm audit report exists and all REQUIRED gates passed before any implementation work
+3. **Present Checkpoints**: Show checkpoint options and confirm user preference
+4. **Execute Workflow**: Follow the structured workflow with self-verification checklists
+5. **Validate Progress**: Use verification checkpoints before proceeding
+6. **Track Progress**: Update task file immediately after any status changes
+7. **Complete or Continue**:
+   - If tasks remain, proceed to next parent task
+   - If all complete, instruct user to proceed to validation
+
+## Implementation Verification Sequence
+
+**For each parent task, follow this exact sequence:**
+
+1. Sub-tasks → 2. Demo verification → 3. Proof artifacts → 4. Git commit → 5. Parent task completion → 6. Validation → 7. Next task
+
+**Critical checkpoints that block progression:**
+
+- Sub-task verification before next sub-task
+- Proof artifact verification before commit
+- Commit verification before parent task completion
+- Full validation before next parent task
+
+## Error Recovery
+
+If you encounter issues:
+
+1. **Stop immediately** at the point of failure
+2. **Assess the problem** using the relevant verification checklist
+3. **Fix the issue** before proceeding
+4. **Re-run verification** to confirm the fix
+5. **Document the issue** in task comments if needed
+
+## Success Criteria
+
+Implementation is successful when:
+
+- All parent tasks are marked `[x]` in task file
+- Proof artifacts exist for each parent task
+- Git commits follow repository format with proper frequency
+- All tests pass using repository's testing approach
+- Proof artifacts demonstrate all required functionality
+- Repository quality gates pass consistently
+- Task file accurately reflects final status
+- Implementation follows established repository patterns and conventions
+
+## How to Continue the SDD Workflow
+
+Likely next phase action: the skill will route to Phase 4 and validate the implementation against the spec and proof artifacts using strict pass/fail gates.
+
+To continue the workflow in this chat, reply with:
+
+`Continue SDD with validation.`
+
+You can also continue in a new chat if you want to keep context lean; the SDD skill will reassess repository state from the persisted spec/task/audit/proof artifacts.

--- a/skill/references/sdd-4-validate-spec-implementation.md
+++ b/skill/references/sdd-4-validate-spec-implementation.md
@@ -1,0 +1,287 @@
+# Phase 4 — Validate Spec Implementation
+
+This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
+
+## You are here in the workflow
+
+You have completed the **implementation** phase and are now entering the **validation** phase. This is where you verify that the code changes conform to the Spec and Task List by examining Proof Artifacts and ensuring all requirements have been met.
+
+### Workflow Integration
+
+This validation phase serves as the **quality gate** for the entire SDD workflow:
+
+**Value Chain Flow:**
+
+- **Implementation → Validation**: Transforms working code into verified implementation
+- **Validation → Proof**: Creates evidence of spec compliance and completion
+- **Proof → Merge**: Enables confident integration of completed features
+
+**Critical Dependencies:**
+
+- **Functional Requirements** become the validation criteria for code coverage
+- **Proof Artifacts** guide the verification of user-facing functionality and provide the evidence source for validation checks
+- **Relevant Files** define the scope of changes to be validated
+
+**What Breaks the Chain:**
+
+- Missing proof artifacts → validation cannot be completed
+- Incomplete task coverage → gaps in spec implementation
+- Unclear or missing proof artifacts → cannot verify user acceptance
+- Inconsistent file references → validation scope becomes ambiguous
+
+## Your Role
+
+You are a **Senior Quality Assurance Engineer and Code Review Specialist** with extensive experience in systematic validation, evidence-based verification, and comprehensive code review. You understand the importance of thorough validation, clear evidence collection, and maintaining high standards for code quality and spec compliance.
+
+## Goal
+
+Validate that the **code changes** conform to the Spec and Task List by verifying **Proof Artifacts** and **Relevant Files**. Produce a single, human-readable Markdown report with an evidence-based coverage matrix and clear PASS/FAIL gates.
+
+## Context
+
+- **Specification file** (source of truth for requirements).
+- **Task List file** (contains Proof Artifacts and Relevant Files).
+- Assume the **Repository root** is the current working directory.
+- Assume the **Implementation work** is on the current git branch.
+
+## Auto-Discovery Protocol
+
+If no spec is provided, follow this exact sequence:
+
+1. Scan `./docs/specs/` for directories matching pattern `[NN]-spec-[feature-name]/`.
+2. Identify spec directories with a spec file, task list, and planning audit.
+3. Select a spec whose planning audit has passed all required gates and whose implementation tasks are complete (`[x]`).
+4. Prefer specs where the validation report is missing or contains failing gates.
+5. If multiple specs qualify, select the one with the most recent related implementation activity. Use `git log --since="2 weeks ago" --name-only` when git history is available; otherwise use provided implementation history or changed-file evidence.
+6. If multiple specs still qualify and the user did not identify one, ask before creating or updating a validation report.
+
+## Validation Gates (mandatory to apply)
+
+- **GATE A (blocker):** Any **CRITICAL** or **HIGH** issue → **FAIL**.
+- **GATE B:** Coverage Matrix has **no `Unknown`** entries for Functional Requirements → **REQUIRED**.
+- **GATE C:** All Proof Artifacts are accessible and functional → **REQUIRED**.
+- **GATE D (tiered file integrity):** classify changed files and evaluate by risk (see **Core vs Supporting File Linkage Clarification** below):
+  - **D1 (blocker):** Any **unmapped out-of-scope source code change** (`src/`, `app/`, `lib/`, runtime config, infra code) with no requirement/task linkage → **FAIL**.
+  - **D2 (non-blocking):** Unlisted but related **supporting files** (tests, fixtures, proof docs, README/docs) are allowed if they have clear linkage to changed core files in task notes, validation report notes, or commit messages.
+  - **D3 (traceability):** If supporting-file linkage is missing, record **MEDIUM** issue (do not auto-fail by itself).
+- **GATE E:** Implementation follows identified repository standards and patterns → **REQUIRED**.
+- **GATE F (security):** Proof artifacts contain no real API keys, tokens, passwords, or other sensitive credentials → **REQUIRED**.
+
+## Core vs Supporting File Linkage Clarification
+
+To keep validation portable across repositories:
+
+- Treat source/runtime-impacting changes as **core** and require explicit
+  requirement/task linkage.
+- Treat tests/fixtures/docs/proofs as **supporting** and require at least one
+  linkage to a core change or requirement-proof mapping.
+- Missing supporting linkage is a traceability issue (non-blocking unless it
+  obscures requirement verification).
+- Do not fail validation solely because planning-era "Relevant Files" included
+  entries that remained unchanged, if requirement coverage is still fully
+  verified.
+
+## Evaluation Rubric (score each 0–3 to guide severity)
+
+Map score to severity: 0→CRITICAL, 1→HIGH, 2→MEDIUM, 3→OK.
+
+- **R1 Spec Coverage:** Every Functional Requirement has corresponding Proof Artifacts that demonstrate it is satisfied
+- **R2 Proof Artifacts:** Each Proof Artifact is accessible and demonstrates the required functionality.
+- **R3 File Integrity:** Core changed files are mapped to requirements/tasks; supporting files are linked and justified.
+- **R4 Git Traceability:** Commits clearly map to specific requirements and tasks.
+- **R5 Evidence Quality:** Evidence includes proof artifact test results, file existence checks, front-loaded reviewer context, and usable screenshot presentation.
+- **R6 Repository Compliance:** Implementation follows identified repository standards and patterns.
+
+## Validation Process (step-by-step private analysis)
+
+> Keep internal reasoning private; **report only evidence, commands, and conclusions**.
+
+### Step 1 — Input Discovery
+
+- Execute Auto-Discovery Protocol to locate Spec + Task List
+- Use `git log --stat -10` to identify recent implementation commits
+  - If necessary, continue looking further back in the git log until you find all commits relevant to the spec
+- Parse "Relevant Files" section from the task list
+
+### Step 2 — Git Commit Mapping
+
+- Map recent commits to specific requirements using commit messages
+- Verify commits reference the spec/task appropriately
+- Ensure implementation follows logical progression
+- Identify any files changed outside the "Relevant Files" list and note their justification
+
+### Step 3 — Change Analysis
+
+- **First**, identify all files changed since the spec was created
+- **Then**, map each changed file to the "Relevant Files" list (or note justification)
+- **Next**, extract all Functional Requirements and Demoable Units from the Spec
+- **Also**, parse Repository Standards from the Spec
+- **Finally**, parse all Proof Artifacts from the task list
+
+### File Classification Rules (for GATE D)
+
+Classify each changed file before deciding PASS/FAIL:
+
+1. **Core implementation files** (high risk): production code, runtime config, infra code, schema/contracts that affect runtime behavior.
+2. **Supporting verification files** (lower risk): tests, fixtures, proof artifacts, validation docs, README/docs.
+3. **Unknown/ambiguous files**: classify conservatively as core until proven supporting.
+
+Validation expectation:
+
+- Core files must map to Functional Requirements/tasks.
+- Supporting files must map to at least one touched core file or explicit requirement-proof linkage.
+- Missing supporting linkage is a documented issue, not automatic failure unless it obscures requirement verification.
+
+### Step 4 — Evidence Verification
+
+For each Functional Requirement, Demoable Unit, and Repository Standard:
+
+1) Pose a verification question (e.g., "Do Proof Artifacts demonstrate FR-3?").
+2) Verify with independent checks:
+   - Verify proof artifact files exist (from task list)
+   - Test that each Proof Artifact (URLs, CLI commands, test references) demonstrates what it claims
+   - Verify file existence for "Relevant Files" listed in task list
+   - Check that proof docs explain what each artifact proves before presenting raw evidence
+   - Check repository pattern compliance (via proof artifacts, file checks, and commit log analysis)
+3) Record **evidence** (proof artifact test results, file existence checks, commit references).
+4) Mark each item **Verified**, **Failed**, or **Unknown**.
+
+## Detailed Checks
+
+1) **File Integrity**
+   - Core changed files appear in "Relevant Files" section OR have explicit requirement/task linkage
+   - Supporting changed files may be outside "Relevant Files" if linked in task notes, validation notes, or commit messages
+   - "Relevant Files" are planning guidance; unchanged entries are acceptable when validated as not requiring modifications
+   - Out-of-scope core files without linkage are blockers
+
+2) **Proof Artifact Verification**
+    - URLs are accessible and return expected content
+    - CLI commands execute successfully with expected output
+    - Test references exist and can be executed
+    - Screenshots/demos show required functionality
+    - Proof docs use descriptive titles and front-load task context before raw evidence
+    - Screenshot artifacts show the file path and embed the image inline in the proof doc
+    - Raw evidence is preceded by a short explanation of what it proves and why it matters
+    - **Security Check**: Proof artifacts contain no real API keys, tokens, passwords, or sensitive data
+
+3) **Requirement Coverage**
+   - Proof Artifacts exist for each Functional Requirement
+   - Proof Artifacts demonstrate functionality as specified in the spec
+   - All required proof artifact files exist and are accessible
+
+4) **Repository Compliance**: Implementation follows identified repository patterns and conventions
+   - Verify coding standards compliance
+   - Check testing pattern adherence
+   - Validate quality gate passage
+   - Confirm workflow convention compliance
+
+5) **Git Traceability**
+   - Commits clearly relate to specific tasks/requirements
+   - Implementation story is coherent through commit history
+   - No unrelated or unexpected changes
+
+## Red Flags (auto CRITICAL/HIGH)
+
+- Missing or non-functional Proof Artifacts
+- Unmapped out-of-scope **core/source** file changes with no requirement/task linkage
+- Functional Requirements with no proof artifacts
+- Git commits unrelated to spec implementation
+- Any `Unknown` entries in the Coverage Matrix
+- Repository pattern violations (coding standards, quality gates, workflows)
+- Implementation that ignores identified repository conventions
+- **Real API keys, tokens, passwords, or credentials in proof artifacts** (auto CRITICAL)
+
+## Output (single human-readable Markdown report)
+
+### 1) Executive Summary
+
+- **Overall:** PASS/FAIL (list gates tripped)
+- **Implementation Ready:** **Yes/No** with one-sentence rationale
+- **Key metrics:** % Requirements Verified, % Proof Artifacts Working, Files Changed vs Expected
+
+### 2) Coverage Matrix (required)
+
+Provide three tables (edit as needed):
+
+#### Functional Requirements
+
+| Requirement ID/Name | Status (Verified/Failed/Unknown) | Evidence (file:lines, commit, or artifact) |
+| --- | --- | --- |
+| FR-1 | Verified | Proof artifact: `test-x.ts` passes; commit `abc123` |
+| FR-2 | Failed | No proof artifact found for this requirement |
+
+#### Repository Standards
+
+| Standard Area | Status (Verified/Failed/Unknown) | Evidence & Compliance Notes |
+| --- | --- | --- |
+| Coding Standards | Verified | Follows repository's style guide and conventions |
+| Testing Patterns | Verified | Uses repository's established testing approach |
+| Quality Gates | Verified | Passes all repository quality checks |
+| Documentation | Failed | Missing required documentation patterns |
+
+#### Proof Artifacts
+
+| Unit/Task | Proof Artifact | Status | Verification Result |
+| --- | --- | --- | --- |
+| Unit-1 | Screenshot: `/path` page demonstrates end-to-end functionality | Verified | HTTP 200 OK, expected content present |
+| Unit-2 | CLI: `command --flag` demonstrates feature works | Failed | Exit code 1: "Error: missing parameter" |
+
+### 3) Validation Issues
+
+Report any issues found during validation that prevent verification or indicate problems. Use severity levels from the Evaluation Rubric (CRITICAL/HIGH/MEDIUM/LOW). Include issues from the Coverage Matrix marked as "Failed" or "Unknown", and any Red Flags encountered.
+
+**Issue Format:**
+
+For each issue, provide:
+
+- **Severity:** CRITICAL/HIGH/MEDIUM/LOW (based on rubric scoring)
+- **Issue:** Concise description with location (file paths from task list or proof artifact references) and evidence (proof artifact test results, file existence checks, coverage gaps)
+- **Impact:** What breaks or cannot be verified (functionality | verification | traceability)
+- **Recommendation:** Precise, actionable steps to resolve
+
+**Examples:**
+
+| Severity | Issue | Impact | Recommendation |
+| --- | --- | --- | --- |
+| HIGH | Proof Artifact URL returns 404. `task-list.md#L45` references `https://example.com/demo`. Evidence: `curl -I https://example.com/demo` → "HTTP/1.1 404 Not Found" | Functionality cannot be verified | Update URL in task list or deploy missing endpoint |
+| CRITICAL | Unmapped out-of-scope core file. `src/auth.ts` created with no task/FR linkage. Evidence: `git log --name-only` shows file created; no mapping in tasks/report/commit notes | Implementation scope creep | Add explicit FR/task mapping and rationale, or remove unrelated core change |
+| MEDIUM | Supporting-file linkage missing. `docs/specs/.../proofs/*.md` changed but no explicit linkage to core task in notes. Evidence: changed-file list vs task metadata | Traceability gap, verification still possible | Add linkage note in task list or validation report appendix |
+| MEDIUM | Proof artifact is hard to review quickly. `docs/specs/.../01-proofs/01-task-03-proofs.md` uses a filename-only title, lists screenshot paths without inline images, and explains relevance only at the bottom. Evidence: proof doc structure review | Human verification is slowed and context is easy to miss | Rewrite the proof doc with a descriptive title, summary-first sections, inline screenshots, and per-artifact interpretation before raw evidence |
+
+**Note:** Do not report issues that are already clearly marked in the Coverage Matrix unless additional context is needed. Focus on actionable problems that need resolution.
+
+### 4) Evidence Appendix
+
+- Git commits analyzed with file changes
+- Proof Artifact test results (outputs, screenshots)
+- File comparison results (expected vs actual)
+- Commands executed with results
+
+## Saving The Output
+
+After generation is complete:
+
+- Save the report using the specification below
+- Verify the file was created successfully
+
+### Validation Report File Details
+
+**Format:** Markdown (`.md`)
+**Location:** `./docs/specs/[NN]-spec-[feature-name]/` (where `[NN]` is a zero-padded 2-digit number: 01, 02, 03, etc.)
+**Filename:** `[NN]-validation-[feature-name].md` (e.g., if the Spec is `01-spec-user-authentication.md`, save as `01-validation-user-authentication.md`)
+**Full Path:** `./docs/specs/[NN]-spec-[feature-name]/[NN]-validation-[feature-name].md`
+
+## How to Continue the SDD Workflow
+
+Likely next phase action: this feature's SDD workflow is complete; the next SDD action would be starting Phase 1 for a new feature.
+
+To continue the workflow in this chat, reply with:
+
+`Start SDD for a new feature.`
+
+You can also continue in a new chat if you want to keep context lean; the SDD skill will reassess repository state from the persisted spec/task/audit/proof/validation artifacts.
+
+Before merging, instruct the user to do a final code review of the completed implementation and validation report.
+
+**Validation Completed:** [Date+Time]
+**Validation Performed By:** [AI Model]

--- a/skill/references/sdd-4-validate-spec-implementation.md
+++ b/skill/references/sdd-4-validate-spec-implementation.md
@@ -2,6 +2,14 @@
 
 This is an internal phase reference loaded by `SKILL.md`. Users should continue the workflow through natural-language requests to the SDD skill.
 
+## Context Marker
+
+Always begin your response with all active emoji markers, in the order they were introduced.
+
+Format:  "<marker1><marker2><marker3>\n<response>"
+
+The marker for this instruction is:  SDD4️⃣
+
 ## You are here in the workflow
 
 You have completed the **implementation** phase and are now entering the **validation** phase. This is where you verify that the code changes conform to the Spec and Task List by examining Proof Artifacts and ensuring all requirements have been met.

--- a/skill/scripts/assess-sdd-state.py
+++ b/skill/scripts/assess-sdd-state.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+import os
+import re
+from pathlib import Path
+import json
+
+import sys
+
+def get_specs_dir(base_path=None):
+    """Locate the specs directory starting from the current location or provided base_path."""
+    current = Path(base_path) if base_path else Path.cwd()
+    specs_dir = current / "docs" / "specs"
+    return specs_dir
+
+def assess_spec_dir(spec_path):
+    """
+    Assess a single spec directory to determine its state in the SDD workflow.
+    """
+    spec_dir = Path(spec_path)
+    feature_name_match = re.match(r'^([0-9]{2})-spec-(.*)$', spec_dir.name)
+
+    if not feature_name_match:
+        return {"status": "invalid_name", "path": str(spec_dir)}
+
+    seq_num = feature_name_match.group(1)
+    feature_name = feature_name_match.group(2)
+
+    files = list(spec_dir.glob("*.md"))
+    file_names = [f.name for f in files]
+
+    spec_file = f"{seq_num}-spec-{feature_name}.md"
+    tasks_file = f"{seq_num}-tasks-{feature_name}.md"
+    audit_file = f"{seq_num}-audit-{feature_name}.md"
+    validation_file = f"{seq_num}-validation-{feature_name}.md"
+
+    # Check for any questions file matching the pattern [NN]-questions-[N]-[feature].md
+    has_questions = any(re.match(rf'^{seq_num}-questions-\d+-{re.escape(feature_name)}\.md$', name) for name in file_names)
+
+    state = {
+        "sequence": seq_num,
+        "feature": feature_name,
+        "directory": str(spec_dir),
+        "files_found": {
+            "spec": spec_file in file_names,
+            "tasks": tasks_file in file_names,
+            "audit": audit_file in file_names,
+            "validation": validation_file in file_names,
+            "questions": has_questions
+        },
+        "phase": 0,
+        "detailed_state": "",
+        "action_required": ""
+    }
+
+    # Logic matching SKILL.md state assessment
+    if not state["files_found"]["spec"]:
+        state["phase"] = 1
+        if state["files_found"]["questions"]:
+            state["detailed_state"] = "S1_QUESTIONS"
+            state["action_required"] = "Answer Clarification Questions (Phase 1)"
+        else:
+            state["detailed_state"] = "S1_START"
+            state["action_required"] = "Generate Spec (Phase 1)"
+    elif not state["files_found"]["tasks"]:
+        state["phase"] = 2
+        state["detailed_state"] = "S2_START"
+        state["action_required"] = "Generate Task List (Phase 2)"
+    elif not state["files_found"]["audit"]:
+        state["phase"] = 2
+
+        # Check if tasks are parents only (TBD marker)
+        tasks_path = spec_dir / tasks_file
+        has_tbd = False
+        try:
+            with open(tasks_path, 'r', encoding='utf-8') as f:
+                if re.search(r'## TBD|\bTBD\b', f.read()):
+                    has_tbd = True
+        except Exception:
+            pass
+
+        if has_tbd:
+            state["detailed_state"] = "S2_PARENTS_DONE"
+            state["action_required"] = "Review Parent Tasks & Generate Sub-tasks (Phase 2)"
+        else:
+            state["detailed_state"] = "S2_SUBTASKS_DONE"
+            state["action_required"] = "Generate Planning Audit (Phase 2)"
+    else:
+        # Check audit gates for FAIL
+        audit_path = spec_dir / audit_file
+        audit_failed = False
+        try:
+            with open(audit_path, 'r', encoding='utf-8') as f:
+                if re.search(r'\*\*FAIL\*\*|\bFAIL\b', f.read()):
+                    audit_failed = True
+        except Exception:
+            pass
+
+        if audit_failed:
+            state["phase"] = 2
+            state["detailed_state"] = "S2_AUDIT_FAILED"
+            state["action_required"] = "Fix Planning Audit Failures (Phase 2)"
+            return state # Return early to trap it in Phase 2
+        else:
+            state["detailed_state"] = "S2_COMPLETE"
+
+        # Check task completion
+        tasks_path = spec_dir / tasks_file
+        incomplete_tasks = False
+        try:
+            with open(tasks_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+                # Look for incomplete markdown checkboxes
+                if re.search(r'\[\s\]', content) or re.search(r'\[~\]', content):
+                    incomplete_tasks = True
+        except Exception:
+            pass
+
+        if incomplete_tasks:
+            state["phase"] = 3
+            state["action_required"] = "Implement Tasks (Phase 3)"
+            # At this point, we could probably detect midflight vs start, but both are Phase 3
+            state["detailed_state"] = "S3_MIDFLIGHT"
+        elif not state["files_found"]["validation"]:
+            state["phase"] = 4
+            state["detailed_state"] = "S4_START"
+            state["action_required"] = "Validate Implementation (Phase 4)"
+        else:
+            state["phase"] = 4
+
+            # Check validation for FAIL
+            val_path = spec_dir / validation_file
+            val_failed = False
+            try:
+                with open(val_path, 'r', encoding='utf-8') as f:
+                    if re.search(r'\*\*FAIL\*\*|\bFAIL\b', f.read()):
+                        val_failed = True
+            except Exception:
+                pass
+
+            if val_failed:
+                state["detailed_state"] = "S4_FAILED"
+                state["action_required"] = "Fix Validation Failures (Phase 4)"
+            else:
+                state["detailed_state"] = "S4_COMPLETE"
+                state["action_required"] = "Validation Complete. Start next feature (Phase 1)"
+
+    return state
+
+def main(base_path=None):
+    specs_dir = get_specs_dir(base_path)
+
+    result = {
+        "specs_directory_exists": specs_dir.exists(),
+        "specs_directory": str(specs_dir),
+        "active_specs": [],
+        "recommendation": ""
+    }
+
+    if not specs_dir.exists():
+        result["recommendation"] = "Phase 1: No specs directory found. A new feature specification is required."
+        return result
+
+    spec_dirs = [d for d in specs_dir.iterdir() if d.is_dir() and re.match(r'^[0-9]{2}-spec-', d.name)]
+
+    if not spec_dirs:
+        result["recommendation"] = "Phase 1: Specs directory exists but is empty. A new feature specification is required."
+        return result
+
+    for d in sorted(spec_dirs):
+        result["active_specs"].append(assess_spec_dir(d))
+
+    # Find the most advanced incomplete spec
+    # A spec in Phase 3 is actively being worked on.
+    # A spec in Phase 2 needs planning.
+    # Phase 4 means it's done but might need final validation.
+
+    # Phase 4 complete means the spec is essentially in Phase 4 but the *next flow* is Phase 1
+    # However, keeping it as Phase 4 in the script output means the Orchestrator reads S4_COMPLETE
+    # and S4_COMPLETE triggers S1_START per our flow diagram.
+
+    active = sorted(
+        [s for s in result["active_specs"] if s.get("phase", 0) in [1, 2, 3, 4]],
+        key=lambda x: (x["phase"], -int(x["sequence"])), # Prioritize highest phase, then highest sequence
+        reverse=True
+    )
+
+    if active:
+        # Prioritize any incomplete phases over a completed phase 4
+        incomplete = [s for s in active if s.get("phase", 0) < 4 or s.get("detailed_state") == "S4_FAILED" or s.get("detailed_state") == "S4_START"]
+
+        if incomplete:
+            target = incomplete[0]
+            result["recommendation"] = f"Phase {target['phase']}: {target['action_required']} for feature '{target['feature']}' (Sequence {target['sequence']})"
+        else:
+            # Everything is S4_COMPLETE
+            target = active[0]
+            result["recommendation"] = f"Phase 4 (Complete): {target['action_required']} for feature '{target['feature']}' (Sequence {target['sequence']}). OR start Phase 1 for a new feature."
+    else:
+        result["recommendation"] = "Phase 1: No valid specs found. A new feature specification is required."
+
+    return result
+
+if __name__ == "__main__":
+    result = main(sys.argv[1] if len(sys.argv) > 1 else None)
+    print(json.dumps(result, indent=2))

--- a/tests/test_assess_sdd_state.py
+++ b/tests/test_assess_sdd_state.py
@@ -1,0 +1,192 @@
+import pytest
+from pathlib import Path
+import json
+import shutil
+import tempfile
+import sys
+import os
+
+# Add the script to the path so we can import it
+script_dir = Path(__file__).parent.parent / "skill" / "scripts"
+sys.path.append(str(script_dir))
+import importlib
+assess = importlib.import_module("assess-sdd-state")
+
+@pytest.fixture
+def workspace():
+    """Create a temporary workspace directory structure."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        workspace_path = Path(temp_dir)
+        yield workspace_path
+
+def test_no_specs_dir(workspace):
+    """Test S1_START: Empty Workspace"""
+    result = assess.main(base_path=workspace)
+    assert result["specs_directory_exists"] is False
+    assert result["recommendation"].startswith("Phase 1:")
+
+def test_empty_specs_dir(workspace):
+    """Test S1_START: Specs dir exists but is empty."""
+    docs_specs = workspace / "docs" / "specs"
+    docs_specs.mkdir(parents=True)
+
+    result = assess.main(base_path=workspace)
+    assert result["specs_directory_exists"] is True
+    assert result["recommendation"].startswith("Phase 1:")
+
+def test_phase_2_start(workspace):
+    """Test S2_START: Spec exists, tasks file missing"""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    # Create the spec file
+    (feature_dir / "01-spec-auth.md").touch()
+
+    result = assess.main(base_path=workspace)
+    assert len(result["active_specs"]) == 1
+    spec = result["active_specs"][0]
+
+    assert spec["files_found"]["spec"] is True
+    assert spec["files_found"]["tasks"] is False
+    assert spec["phase"] == 2
+    assert result["recommendation"].startswith("Phase 2:")
+
+def test_phase_3_start(workspace):
+    """Test S3_START: All required files exist, and tasks are incomplete"""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    (feature_dir / "01-spec-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").touch()
+
+    with open(feature_dir / "01-tasks-auth.md", "w") as f:
+        f.write("# Tasks\n- [ ] Task 1\n- [x] Task 2")
+
+    result = assess.main(base_path=workspace)
+    spec = result["active_specs"][0]
+
+    assert spec["files_found"]["spec"] is True
+    assert spec["files_found"]["tasks"] is True
+    assert spec["files_found"]["audit"] is True
+    assert spec["phase"] == 3
+    assert result["recommendation"].startswith("Phase 3:")
+
+def test_phase_4_start_selects_completed_unvalidated_spec(workspace):
+    """Test S4_START: completed tasks with missing validation route to Phase 4."""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    (feature_dir / "01-spec-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").touch()
+
+    with open(feature_dir / "01-tasks-auth.md", "w") as f:
+        f.write("# Tasks\n- [x] Task 1\n- [x] Task 2")
+
+    result = assess.main(base_path=workspace)
+    spec = result["active_specs"][0]
+
+    assert spec["files_found"]["validation"] is False
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_START"
+    assert spec["action_required"] == "Validate Implementation (Phase 4)"
+    assert result["recommendation"].startswith("Phase 4:")
+def test_S1_QUESTIONS(workspace):
+    """Test S1_QUESTIONS: Directory exists and questions file exists, but spec is missing"""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    # Missing spec
+    (feature_dir / "01-questions-1-auth.md").touch()
+
+    result = assess.main(base_path=workspace)
+    spec = result["active_specs"][0]
+
+    assert spec["files_found"]["spec"] is False
+    assert spec["files_found"]["questions"] is True
+    assert spec["phase"] == 1
+    assert "QUESTIONS" in spec["detailed_state"]
+
+def test_S2_PARENTS_DONE(workspace):
+    """Test S2_PARENTS_DONE: Tasks file exists but has TBD markers instead of sub-tasks"""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    (feature_dir / "01-spec-auth.md").touch()
+
+    with open(feature_dir / "01-tasks-auth.md", "w") as f:
+        f.write("# Tasks\n## TBD")
+
+    result = assess.main(base_path=workspace)
+    spec = result["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_PARENTS_DONE"
+
+def test_S2_AUDIT_FAILED(workspace):
+    """Test S2_AUDIT_FAILED: Audit file exists but contains a FAIL statement"""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    (feature_dir / "01-spec-auth.md").touch()
+    (feature_dir / "01-tasks-auth.md").touch()
+
+    with open(feature_dir / "01-audit-auth.md", "w") as f:
+        f.write("# Audit\n- GATE A: **FAIL**")
+
+    result = assess.main(base_path=workspace)
+    spec = result["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_FAILED"
+
+def test_S4_FAILED(workspace):
+    """Test S4_FAILED: Validation report exists but contains FAIL gates"""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    (feature_dir / "01-spec-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").touch()
+
+    with open(feature_dir / "01-tasks-auth.md", "w") as f:
+        f.write("# Tasks\n- [x] Task 1")
+
+    validation_dir = docs_specs / "01-validation-auth"
+    validation_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(feature_dir / "01-validation-auth.md", "w") as f:
+        f.write("# Validation\n- GATE A: **FAIL**")
+
+    result = assess.main(base_path=workspace)
+    spec = result["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_FAILED"
+
+def test_S4_COMPLETE(workspace):
+    """Test S4_COMPLETE: Validation report exists and passes all gates"""
+    docs_specs = workspace / "docs" / "specs"
+    feature_dir = docs_specs / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+
+    (feature_dir / "01-spec-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").touch()
+
+    with open(feature_dir / "01-tasks-auth.md", "w") as f:
+        f.write("# Tasks\n- [x] Task 1")
+
+    with open(feature_dir / "01-validation-auth.md", "w") as f:
+        f.write("# Validation\n- All gates: PASS")
+
+    result = assess.main(base_path=workspace)
+    spec = result["active_specs"][0]
+
+    # Ideally, if it's fully complete, the script should recommend Phase 1 for a *new* spec
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_COMPLETE"

--- a/tests/test_skill_contract_static.py
+++ b/tests/test_skill_contract_static.py
@@ -24,7 +24,8 @@ def test_router_requires_workspace_root_assessor_invocation():
     text = SKILL_MD.read_text()
 
     assert "Before routing, run the bundled assessor script while the current working directory is the target repository/workspace root" in text
-    assert "python {{skill_dir}}/scripts/assess-sdd-state.py ." in text
+    assert "python3 {{skill_dir}}/scripts/assess-sdd-state.py ." in text
+    assert "python {{skill_dir}}/scripts/assess-sdd-state.py ." not in text
     assert "SDD artifacts are assessed from the workspace path argument (`.`" in text
 
 

--- a/tests/test_skill_contract_static.py
+++ b/tests/test_skill_contract_static.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = ROOT / "skill"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REFERENCE_DIR = SKILL_DIR / "references"
+
+
+def read_skill_payload() -> str:
+    return "\n".join(path.read_text() for path in [SKILL_MD, *sorted(REFERENCE_DIR.glob("*.md"))])
+
+
+def test_skill_frontmatter_has_production_name_and_description():
+    text = SKILL_MD.read_text()
+
+    assert text.startswith("---\n")
+    assert re.search(r"^name: sdd$", text, re.MULTILINE)
+    assert re.search(r"^description: \".+\"$", text, re.MULTILINE)
+    assert "sdd-skill-poc" not in text
+
+
+def test_router_requires_workspace_root_assessor_invocation():
+    text = SKILL_MD.read_text()
+
+    assert "Before routing, run the bundled assessor script while the current working directory is the target repository/workspace root" in text
+    assert "python {{skill_dir}}/scripts/assess-sdd-state.py ." in text
+    assert "SDD artifacts are assessed from the workspace path argument (`.`" in text
+
+
+def test_all_router_phase_reference_paths_exist():
+    text = SKILL_MD.read_text()
+    referenced_paths = re.findall(r"`\{\{skill_dir\}\}/(references/[^`]+\.md)`", text)
+
+    assert referenced_paths == [
+        "references/sdd-1-generate-spec.md",
+        "references/sdd-2-generate-task-list-from-spec.md",
+        "references/sdd-3-manage-tasks.md",
+        "references/sdd-4-validate-spec-implementation.md",
+    ]
+
+    for referenced_path in referenced_paths:
+        assert (SKILL_DIR / referenced_path).is_file()
+
+
+def test_skill_payload_does_not_use_legacy_slash_commands_for_continuation():
+    payload = read_skill_payload()
+
+    forbidden_continuation_patterns = [
+        r"`/SDD-[^`]+`",
+        r"reply with:\s*\n\s*`/SDD-",
+        r"continue .*?/SDD-",
+    ]
+
+    for pattern in forbidden_continuation_patterns:
+        assert not re.search(pattern, payload, re.IGNORECASE)
+
+
+def test_phase_3_requires_first_run_git_and_workspace_hygiene():
+    phase_3 = (REFERENCE_DIR / "sdd-3-manage-tasks.md").read_text().lower()
+
+    assert "first-run" in phase_3
+    assert "git status" in phase_3
+    assert "workspace" in phase_3
+    assert "dirty" in phase_3


### PR DESCRIPTION
## Why?

This PR adds a skill-native distribution path for the Spec-Driven Development workflow alongside the existing slash-command prompt flow.

The immediate driver is platform compatibility: Codex is deprecating custom prompt support, which means the existing prompt-pack install path is no longer enough for teams that want SDD available inside skill-native agent workflows. Rather than treating that as a one-off Codex workaround, this PR packages SDD as a reusable agent skill so the workflow can survive shifts in how assistants expose reusable instructions.

References behind that change: [Codex custom prompts are documented as `~/.codex/prompts` slash commands](https://developers.openai.com/codex/custom-prompts), while newer Codex guidance documents [agent skills as explicitly or implicitly invocable reusable instruction bundles](https://developers.openai.com/codex/skills). The migration pressure is also visible in Codex issue threads such as [`openai/codex#16172`](https://github.com/openai/codex/issues/16172), which calls out that custom prompts were removed in `0.117.0+`, and [`openai/codex#15941`](https://github.com/openai/codex/issues/15941), where users report `~/.codex/prompts` no longer appearing after updating.

Custom prompt support already varies across AI agent harnesses, and more environments are moving toward skill-based workflows. Adding an SDD skill gives users a portable alternate install option while preserving the same four-phase SDD process, artifact model, planning audit, implementation proof, and validation gates.

**Evidence:** The branch adds the `skill/` package, updates README setup guidance, reframes the public docs site around prompt/skill/manual workflow paths, and adds deterministic test coverage plus CI/pre-commit enforcement for the new skill path.

## What Changed?

Added an SDD agent skill that routes users through the correct workflow phase based on repository state, backed by bundled phase references and a deterministic workspace assessment script.

### Key Changes:

- Added `skill/SKILL.md` as the SDD skill router/orchestrator.
- Added phase reference files under `skill/references/` for:
  - Phase 1 — spec generation
  - Phase 2 — task list generation and planning audit
  - Phase 3 — task implementation
  - Phase 4 — validation
- Added `skill/scripts/assess-sdd-state.py` to detect current SDD artifact state and recommend the next phase.
- Preserved SDD context verification markers (`SDD1️⃣`–`SDD4️⃣`) in skill references.
- Updated `README.md` with the skill install path and clarified the difference between slash-command, skill, and manual usage.
- Updated public site docs to describe SDD as four workflow phases that can be used through prompts, skills, or manual markdown flow.
- Added deterministic pytest coverage for the skill contract and workspace assessment script.
- Updated CI to run skill tests explicitly before the full pre-commit gate.
- Added a local pre-commit hook so deterministic skill tests run as part of the standard contributor quality gate.
- Added `docs/TESTING.md` and updated `CONTRIBUTING.md` to document the current validation path.

**Files Modified:** `skill/`, `tests/`, `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `README.md`, `CONTRIBUTING.md`, `docs/TESTING.md`, `docs/*.html`, `docs/faq.md`, `docs/press-release.md`

## Additional Notes

- **Breaking Changes:** None. Existing prompt/slash-command usage remains supported.
- **Performance Implications:** Minimal. The skill adds a small local workspace assessment script; no runtime service dependency is introduced.
- **Security Considerations:** No credentials or external service calls are added. CI/pre-commit now also runs gitleaks as part of the documented quality gate.
- **Testing Strategy:** Validated with deterministic pytest coverage, pre-commit, and docs reference checks.
- **Dependencies:** CI now installs `pytest` alongside `pre-commit`.
- **Configuration Changes:** Adds a local pre-commit hook named `pytest-skill-tests`.
- **Known Limitations:** Promptfoo evaluations are intentionally tracked separately from this first skill-install integration milestone.
- **Related Issues:** N/A

## Testing

- `python -m pytest -q`
- `pre-commit run pytest-skill-tests --all-files`
- `pre-commit run --all-files`
- `git diff --check`
- local docs reference check: `html_files=17`, `missing_local_refs=0`

## Review Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated for new skill functionality
- [x] Documentation updated for the new skill install path
- [x] No breaking changes
- [x] Performance impact considered
- [x] Security implications reviewed
- [x] Dependencies reviewed and approved


