### PR TITLE
fix(skill): read audit/validation verdict from authoritative Overall line

### DIFF
--- a/skill/scripts/assess-sdd-state.py
+++ b/skill/scripts/assess-sdd-state.py
@@ -6,6 +6,41 @@ import json
 
 import sys
 
+def _authoritative_verdict(text):
+    """Return the authoritative PASS/FAIL verdict for an audit/validation report.
+
+    The report's Executive Summary carries the verdict on an
+    ``Overall Status: PASS/FAIL`` line (audits) or ``Overall: PASS/FAIL`` line
+    (validations). That line is authoritative; retained run history elsewhere in
+    the report (e.g. a Re-Audit Delta noting ``FAIL -> PASS``) or prose that
+    merely mentions the word FAIL must not flip the verdict.
+
+    Strategy:
+      1. If an "Overall" line exists, the FIRST PASS/FAIL token on it wins --
+         that is the status stated right after the colon. A parenthetical note
+         such as ``PASS (was FAIL on run 1)`` therefore stays PASS, and
+         run-to-run history (kept in a separate Re-Audit Delta section, never on
+         the Overall line) is ignored.
+      2. Otherwise fall back to a per-gate scan: any FAIL marks the report
+         failed (preserves behaviour for reports without a summary line).
+
+    Returns "PASS", "FAIL", or None when no verdict can be determined.
+    """
+    overall_line = re.compile(r'^.*\boverall\b[^\n]*?:[^\n]*$', re.IGNORECASE | re.MULTILINE)
+    token = re.compile(r'\b(PASS|FAIL)\b')
+
+    for line in overall_line.findall(text):
+        found = token.findall(line)
+        if found:
+            return found[0].upper()
+
+    # No authoritative line: fall back to a whole-document gate scan.
+    if re.search(r'\*\*FAIL\*\*|\bFAIL\b', text):
+        return "FAIL"
+    if re.search(r'\bPASS\b', text):
+        return "PASS"
+    return None
+
 def get_specs_dir(base_path=None):
     """Locate the specs directory starting from the current location or provided base_path."""
     current = Path(base_path) if base_path else Path.cwd()
@@ -85,12 +120,12 @@ def assess_spec_dir(spec_path):
             state["detailed_state"] = "S2_SUBTASKS_DONE"
             state["action_required"] = "Generate Planning Audit (Phase 2)"
     else:
-        # Check audit gates for FAIL
+        # Check audit gates for FAIL using the authoritative verdict line
         audit_path = spec_dir / audit_file
         audit_failed = False
         try:
             with open(audit_path, 'r', encoding='utf-8') as f:
-                if re.search(r'\*\*FAIL\*\*|\bFAIL\b', f.read()):
+                if _authoritative_verdict(f.read()) == "FAIL":
                     audit_failed = True
         except Exception:
             pass
@@ -127,12 +162,12 @@ def assess_spec_dir(spec_path):
         else:
             state["phase"] = 4
 
-            # Check validation for FAIL
+            # Check validation for FAIL using the authoritative verdict line
             val_path = spec_dir / validation_file
             val_failed = False
             try:
                 with open(val_path, 'r', encoding='utf-8') as f:
-                    if re.search(r'\*\*FAIL\*\*|\bFAIL\b', f.read()):
+                    if _authoritative_verdict(f.read()) == "FAIL":
                         val_failed = True
             except Exception:
                 pass

--- a/skill/scripts/assess-sdd-state.py
+++ b/skill/scripts/assess-sdd-state.py
@@ -7,7 +7,7 @@ import json
 import sys
 
 def _authoritative_verdict(text):
-    """Return the authoritative PASS/FAIL verdict for an audit/validation report.
+    r"""Return the authoritative PASS/FAIL verdict for an audit/validation report.
 
     The report's Executive Summary carries the verdict on an
     ``Overall Status: PASS/FAIL`` line (audits) or ``Overall: PASS/FAIL`` line
@@ -15,24 +15,63 @@ def _authoritative_verdict(text):
     the report (e.g. a Re-Audit Delta noting ``FAIL -> PASS``) or prose that
     merely mentions the word FAIL must not flip the verdict.
 
+    The authoritative-line regex accepts optional indentation, a Markdown list
+    marker, and bold formatting around ``Overall`` / ``Overall Status`` and the
+    verdict. It deliberately requires a colon followed immediately by the
+    captured verdict, so prose such as ``Overall notes: FAIL on run 1`` cannot
+    override an explicit current status.
+
+    Regex anatomy (``^`` / ``$`` apply per line; matching is case-insensitive)::
+
+    ^\s*
+    │ │
+    │ └─ Allow leading whitespace
+    └── Start at the beginning of a line
+    (?:[-*+]\s*)?
+    │
+    └─ Optional Markdown list marker:
+    "- ", "* ", or "+ "
+    (?:\*\*)?
+    │
+    └─ Optional opening bold marker: "**"
+    overall
+    │
+    └─ Require the literal label "overall"
+    (?:\s+status)?
+    │
+    └─ Optionally allow the word "status":
+    "Overall"         ✓
+    "Overall Status"  ✓
+    (?:\*\*)?\s*:
+    │       │       │
+    │       │       └─ Require a colon
+    │       └───────── Allow whitespace before it
+    └───────────────── Optional closing bold marker
+    \s*(?:\*\*)?\s*(PASS|FAIL)\b
+    │    │              │          │
+    │    │              │          └─ Prevent matches like "FAILED"
+    │    │              └──────────── Capture the verdict
+    │    └─────────────────────────── Allow bold verdicts: "**PASS**"
+    └──────────────────────────────── Allow spaces after ":"
+
     Strategy:
-      1. If an "Overall" line exists, the FIRST PASS/FAIL token on it wins --
-         that is the status stated right after the colon. A parenthetical note
-         such as ``PASS (was FAIL on run 1)`` therefore stays PASS, and
-         run-to-run history (kept in a separate Re-Audit Delta section, never on
-         the Overall line) is ignored.
+      1. Search for the first explicitly formatted status line and return the
+         PASS/FAIL token immediately after its colon. A parenthetical note such
+         as ``PASS (was FAIL on run 1)`` therefore stays PASS.
       2. Otherwise fall back to a per-gate scan: any FAIL marks the report
          failed (preserves behaviour for reports without a summary line).
 
     Returns "PASS", "FAIL", or None when no verdict can be determined.
     """
-    overall_line = re.compile(r'^.*\boverall\b[^\n]*?:[^\n]*$', re.IGNORECASE | re.MULTILINE)
-    token = re.compile(r'\b(PASS|FAIL)\b')
+    status_line = re.compile(
+        r'^\s*(?:[-*+]\s*)?(?:\*\*)?overall(?:\s+status)?(?:\*\*)?\s*:'
+        r'\s*(?:\*\*)?\s*(PASS|FAIL)\b',
+        re.IGNORECASE | re.MULTILINE,
+    )
 
-    for line in overall_line.findall(text):
-        found = token.findall(line)
-        if found:
-            return found[0].upper()
+    match = status_line.search(text)
+    if match:
+        return match.group(1).upper()
 
     # No authoritative line: fall back to a whole-document gate scan.
     if re.search(r'\*\*FAIL\*\*|\bFAIL\b', text):

--- a/tests/test_assess_sdd_state.py
+++ b/tests/test_assess_sdd_state.py
@@ -290,6 +290,28 @@ def test_audit_overall_fail_still_traps(workspace):
     assert spec["detailed_state"] == "S2_AUDIT_FAILED"
 
 
+def test_audit_non_status_overall_pass_does_not_bypass_failed_gate(workspace):
+    """Only a documented status label may bypass the fallback gate scan."""
+    body = "## Overall discussion: PASS\n\n- GATE A: FAIL\n"
+    _spec_with_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_FAILED"
+
+
+def test_audit_non_status_overall_fail_does_not_override_current_pass(workspace):
+    """Historical prose cannot override the documented current audit status."""
+    body = "## Overall notes: FAIL on run 1\n\n- Overall Status: PASS\n"
+    _spec_with_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 3
+    assert spec["detailed_state"] == "S3_MIDFLIGHT"
+
+
 def _spec_with_validation(workspace, validation_body):
     """Create a workspace whose single spec is complete through validation."""
     feature_dir = workspace / "docs" / "specs" / "01-spec-auth"

--- a/tests/test_assess_sdd_state.py
+++ b/tests/test_assess_sdd_state.py
@@ -190,3 +190,134 @@ def test_S4_COMPLETE(workspace):
     # Ideally, if it's fully complete, the script should recommend Phase 1 for a *new* spec
     assert spec["phase"] == 4
     assert spec["detailed_state"] == "S4_COMPLETE"
+
+
+# ---------------------------------------------------------------------------
+# Authoritative-verdict regression tests
+#
+# The assessor must decide PASS/FAIL from the report's authoritative
+# "Overall Status:" (audit) / "Overall:" (validation) line, NOT by scanning
+# the whole file for the token FAIL. Otherwise a report that failed on run 1
+# and passed on run 2 -- whose Re-Audit Delta retains "FAIL -> PASS" history --
+# or prose that merely mentions the word FAIL is mis-read as a failure, trapping
+# the workflow in the failure state.
+# ---------------------------------------------------------------------------
+
+# A realistic passing re-audit: Executive Summary says PASS, but the retained
+# Re-Audit Delta history still contains the word FAIL.
+AUDIT_FAIL_THEN_PASS = """# 01-audit-auth.md
+
+## Executive Summary
+
+- Overall Status: PASS
+- Required Gate Failures: 0
+- Flagged Risks: 0
+
+## Re-Audit Delta (Runs 2+)
+
+- Changed gate statuses since previous run: Requirement-to-test traceability FAIL -> PASS
+- Still-failing REQUIRED gates: none
+"""
+
+# A passing audit whose prose merely mentions the word FAIL.
+AUDIT_PASS_FAIL_WORD_IN_BODY = """# 01-audit-auth.md
+
+## Executive Summary
+
+- Overall Status: PASS
+- Required Gate Failures: 0
+
+## Notes
+
+All required gates pass; none returned FAIL.
+"""
+
+# A genuine failure with an authoritative FAIL verdict (regression guard).
+AUDIT_GENUINE_FAIL = """# 01-audit-auth.md
+
+## Executive Summary
+
+- Overall Status: FAIL
+- Required Gate Failures: 1
+
+## Gateboard
+
+| Gate | Status | Why it failed (<=10 words) | Exact fix target |
+| --- | --- | --- | --- |
+| Requirement-to-test traceability | FAIL | FR-2 has no mapped test artifact | `## Tasks > 2.0` |
+"""
+
+
+def _spec_with_audit(workspace, audit_body, tasks_body):
+    """Create a workspace whose single spec has spec/tasks/audit files."""
+    feature_dir = workspace / "docs" / "specs" / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "01-spec-auth.md").touch()
+    (feature_dir / "01-tasks-auth.md").write_text(tasks_body)
+    (feature_dir / "01-audit-auth.md").write_text(audit_body)
+    return feature_dir
+
+
+def test_audit_fail_then_pass_history_is_not_failed(workspace):
+    """RED before fix: PASS audit with retained FAIL->PASS history must not trap in Phase 2."""
+    _spec_with_audit(workspace, AUDIT_FAIL_THEN_PASS, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["detailed_state"] != "S2_AUDIT_FAILED"
+    assert spec["phase"] == 3
+    assert spec["detailed_state"] == "S3_MIDFLIGHT"
+
+
+def test_audit_pass_with_fail_word_in_body_is_not_failed(workspace):
+    """RED before fix: PASS audit that merely mentions the word FAIL must not trap in Phase 2."""
+    _spec_with_audit(workspace, AUDIT_PASS_FAIL_WORD_IN_BODY, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["detailed_state"] != "S2_AUDIT_FAILED"
+    assert spec["phase"] == 3
+    assert spec["detailed_state"] == "S3_MIDFLIGHT"
+
+
+def test_audit_overall_fail_still_traps(workspace):
+    """Regression guard: an authoritative Overall Status: FAIL still routes to S2_AUDIT_FAILED."""
+    _spec_with_audit(workspace, AUDIT_GENUINE_FAIL, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_FAILED"
+
+
+def _spec_with_validation(workspace, validation_body):
+    """Create a workspace whose single spec is complete through validation."""
+    feature_dir = workspace / "docs" / "specs" / "01-spec-auth"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "01-spec-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").write_text("- Overall Status: PASS")
+    (feature_dir / "01-tasks-auth.md").write_text("# Tasks\n- [x] Task 1")
+    (feature_dir / "01-validation-auth.md").write_text(validation_body)
+    return feature_dir
+
+
+def test_validation_fail_then_pass_history_is_complete(workspace):
+    """RED before fix: PASS validation with retained FAIL history must read as S4_COMPLETE."""
+    body = "## Summary\n\n- **Overall:** PASS (GATE A was FAIL on run 1, fixed on run 2)\n"
+    _spec_with_validation(workspace, body)
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_COMPLETE"
+
+
+def test_validation_pass_with_fail_word_in_body_is_complete(workspace):
+    """RED before fix: PASS validation that merely mentions FAIL must read as S4_COMPLETE."""
+    body = "## Summary\n\n- **Overall:** PASS\n\nNo gate returned FAIL.\n"
+    _spec_with_validation(workspace, body)
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_COMPLETE"


### PR DESCRIPTION
## Problem

`skill/scripts/assess-sdd-state.py` decides whether an audit or validation report failed by scanning the **entire file** for the token `FAIL`:

```python
if re.search(r'\*\*FAIL\*\*|\bFAIL\b', f.read()):
    audit_failed = True   # -> S2_AUDIT_FAILED, traps the workflow in Phase 2
```

This produces **false positives**. A report that failed on an early run and passed on a later one keeps its history in the documented `Re-Audit Delta` section (e.g. `Requirement-to-test traceability FAIL -> PASS`), and a clean passing report's gateboard header literally reads `Why it failed`. Either makes a genuine `Overall Status: PASS` report read as a failure, trapping the workflow in `S2_AUDIT_FAILED` / `S4_FAILED`.

## Fix

Add `_authoritative_verdict(text)`, which:

1. Reads the verdict from the **first** `PASS`/`FAIL` token on the report's authoritative summary line — `Overall Status:` (audits) / `Overall:` (validations). A parenthetical note like `PASS (was FAIL on run 1)` correctly stays `PASS`; run history kept elsewhere is ignored.
2. Falls back to the previous whole-document gate scan **only when no Overall line exists**, preserving behaviour for gate-only reports.

A genuine `Overall Status: FAIL` still routes to the failure state.

## Tests (TDD)

Added 5 regression cases to `tests/test_assess_sdd_state.py`. Before the fix the 4 false-positive cases were RED and the genuine-failure guard was GREEN; after the fix the full suite is green.

```
20 passed
```

- `test_audit_fail_then_pass_history_is_not_failed`
- `test_audit_pass_with_fail_word_in_body_is_not_failed`
- `test_audit_overall_fail_still_traps` (guard)
- `test_validation_fail_then_pass_history_is_complete`
- `test_validation_pass_with_fail_word_in_body_is_complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow routing logic in a skill script with broad test coverage; no auth, data, or production runtime paths.
> 
> **Overview**
> Fixes false **FAIL** detection in `assess-sdd-state.py` when audit or validation reports are **Overall: PASS** but still mention `FAIL` in history or prose.
> 
> The assessor now uses **`_authoritative_verdict`**, which reads the first `Overall Status:` / `Overall:` line (with optional list/bold formatting) and only falls back to a whole-document `FAIL` scan when that line is missing. Audit and validation checks route to `S2_AUDIT_FAILED` / `S4_FAILED` only when that helper returns **FAIL**.
> 
> **`tests/test_assess_sdd_state.py`** adds regression cases for re-audit deltas, incidental `FAIL` text, genuine failures, non-status “Overall” prose, and validation summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95048042f080d0f0d1a72310b2653381d1313eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->