### PR TITLE
docs: clarify stable migration guide links

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,7 @@
 # Migrate Spec-Driven Development from slash-command prompts to the `sdd` skill
 
+> **Stable link for sharing:** use <https://github.com/liatrio-labs/spec-driven-workflow/blob/main/MIGRATION.md>. Avoid sharing links to temporary PR branches because those branch links may stop working after the PR is merged and the branch is deleted.
+
 If you previously installed Spec-Driven Development (SDD) as four slash-command prompts, you can now install it as one agent skill:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 > [!IMPORTANT]
-> **SDD is now skill-first.** If you previously installed SDD as separate `/SDD-*` slash-command prompts, migrate to the recommended `sdd` skill so your agent can route through the right workflow phase from repository state. Start with the [migration guide](./MIGRATION.md), or update an existing skill install with `npx skills update sdd --yes`.
+> **SDD is now skill-first.** If you previously installed SDD as separate `/SDD-*` slash-command prompts, migrate to the recommended `sdd` skill so your agent can route through the right workflow phase from repository state. Start with the [migration guide](./MIGRATION.md). When sharing the guide outside this repo, use the stable `main` link: <https://github.com/liatrio-labs/spec-driven-workflow/blob/main/MIGRATION.md>. To update an existing skill install, run `npx skills update sdd --yes`.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Clarifies that shared migration-guide links should use the stable `main` URL instead of temporary PR branch URLs.
- Adds the stable URL directly to the migration guide and README migration callout.
- Recreates the previous `docs/sdd-skill-migration-guide` branch so the already-shared Slack branch link resolves again while this follow-up PR is open.

## Testing
- `.venv/bin/python -m pytest -q` — 15 passed
- `pre-commit run --all-files` — passed
- Verified both GitHub URLs return HTTP 200:
  - `https://github.com/liatrio-labs/spec-driven-workflow/blob/docs/sdd-skill-migration-guide/MIGRATION.md`
  - `https://github.com/liatrio-labs/spec-driven-workflow/blob/main/MIGRATION.md`
