### PR TITLE
feat: add invoke: none to SDD skill

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sdd
 description: "Execute the Liatrio Spec-Driven Development (SDD) workflow when explicitly invoked by the user. NOTE: this skill is NOT intended to be dynamically loaded or automatically triggered; it should only ever be explicitly called by the user."
+invoke: none
 ---
 
 # Spec-Driven Workflow Orchestrator


### PR DESCRIPTION
## Summary
Add `invoke: none` frontmatter to SDD skill to prevent automatic framework triggering. Skill must only be explicitly invoked by users.

From client cohort 1 feedback to align plugin repo behavior.

## Test plan
- Verify skill cannot be auto-triggered by framework
- Confirm explicit user invocation still works
- Check SKILL.md frontmatter is valid YAML

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-style frontmatter only; no runtime logic or security-sensitive code paths change.
> 
> **Overview**
> Adds **`invoke: none`** to the SDD skill’s YAML frontmatter in `skill/SKILL.md`, matching the existing contract that the workflow must only run when the user explicitly invokes it.
> 
> This blocks automatic or dynamic loading by the skill framework while leaving explicit user invocation unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09eb25835400daed75230df07b2d7e99dd674358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->