### PR TITLE
fix(sdd): disable model invocation

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sdd
 description: "Execute the Liatrio Spec-Driven Development (SDD) workflow when explicitly invoked by the user. NOTE: this skill is NOT intended to be dynamically loaded or automatically triggered; it should only ever be explicitly called by the user."
+# Note that the as of 2026-07-22 the disable-model-invocation parameter is only supported by the Claude and Cursor harnesses and is not yet part of the official agent skills spec. See https://code.claude.com/docs/en/skills#control-who-invokes-a-skill, https://cursor.com/docs/skills#disabling-automatic-invocation, and https://github.com/agentskills/agentskills/issues/105
 disable-model-invocation: true
 ---
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sdd
 description: "Execute the Liatrio Spec-Driven Development (SDD) workflow when explicitly invoked by the user. NOTE: this skill is NOT intended to be dynamically loaded or automatically triggered; it should only ever be explicitly called by the user."
+disable-model-invocation: true
 ---
 
 # Spec-Driven Workflow Orchestrator


### PR DESCRIPTION
Prevents SDD from accidentally context-bombing your sessions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to skill invocation; no runtime code or workflow logic is modified.
> 
> **Overview**
> Sets **`disable-model-invocation: true`** in the SDD skill frontmatter so harnesses stop auto-loading the orchestrator and inflating session context.
> 
> Adds a short frontmatter comment that the flag is supported on Claude and Cursor as of 2026-07-22, is not in the official Agent Skills spec yet, and links to the relevant docs and spec issue. The existing description already says the skill is user-invoked only; this change makes that behavior explicit for compatible harnesses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ef6bfa13e7d15c1319ce97de46fbcb498788197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->