### PR TITLE
docs(skill): add SDD subagent batch mode guidance

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -19,6 +19,10 @@ This skill manages one SDD phase per invocation unless the loaded phase explicit
 4. Execute the phase instructions or stop at a required approval gate.
 5. Tell the user the selected spec, detected state, current phase, chosen phase reference path, created or updated artifacts, and next recommended natural-language request.
 
+## Delegation Reminder
+
+Whenever you delegate SDD work to a subagent, include explicit instructions for that subagent to read the relevant SDD phase reference file before beginning delegated work. This preserves phase-specific rules when implementation, review, remediation, validation, or artifact generation happens outside the main orchestrator context.
+
 If multiple active specs exist and the user request does not clearly identify one, ask the user which spec to continue before modifying files. If the selection is unambiguous, state why that spec was selected.
 
 ## State Assessment

--- a/skill/references/sdd-3-manage-tasks.md
+++ b/skill/references/sdd-3-manage-tasks.md
@@ -65,9 +65,43 @@ Execute a structured task list to implement a Specification while maintaining cl
    - Pros: Maximum momentum, fastest completion
    - Cons: Less oversight, potential for going off-track
 
+4. **Batch Mode with Subagents**: Complete all tasks sequentially using an implement → review → remediate → repeat loop, with a separate subagent for each part of the loop. See the [Batch Mode with Subagents](#batch-mode-with-subagents) section below for more details.
+   - Best for: larger implementation phases where independent implementation/review/remediation passes improve quality without pausing after every parent task
+   - Pros: preserves batch momentum while adding explicit review pressure and remediation gates
+   - Cons: requires careful orchestration, clean handoffs, and commit verification between subagents
+
 **Default**: If the user doesn't specify, use Task Mode.
 
 **Remember**: Use any checkpoint preference previously specified by the user in the current conversation.
+
+## Batch Mode with Subagents
+
+Use this mode when the user asks for advanced batch mode, requests subagent-driven implementation, or otherwise asks to complete all SDD-3 tasks through an implement/review/remediate loop. The main agent remains the orchestrator and is responsible for sequencing, commit verification, and final reporting.
+
+### Orchestration Rules
+
+1. **Run tasks sequentially**: Work one parent task at a time. Do not start the next parent task until the current task has completed implementation, review, any needed remediation, proof artifact creation, task-state updates, quality gates, and commit verification.
+2. **Use separate subagents for each loop part**:
+   - **Implement subagent**: implements the current parent task using this SDD-3 reference, updates task status, creates/updates proof artifacts, runs relevant tests and quality gates, and commits implementation/proof/task-file changes before returning.
+   - **Review subagent**: reviews the committed implementation against the task list, spec, audit, proof artifacts, repository standards, and this SDD-3 reference. It records actionable findings in a review artifact or task note and commits those review artifacts if any are created.
+   - **Remediate subagent**: fixes only the review findings for the current parent task, reruns the required verification, updates proof artifacts if evidence changed, and commits remediation changes before returning.
+3. **Repeat review/remediate until clean**: After remediation, launch a fresh review subagent. Continue review → remediate until the review subagent reports no blocking findings for the current parent task.
+4. **Require SDD-3 context in every subagent prompt**: Every implementation, review, and remediation subagent prompt must explicitly instruct the subagent to read `skill/references/sdd-3-manage-tasks.md` (or the installed skill's equivalent SDD-3 phase reference) before starting work and to follow its proof, task-state, quality-gate, and commit requirements.
+5. **Verify commits between loop parts**: Before launching the next subagent, the main orchestrator must run `git status --short` and `git log --oneline -1` (or equivalent) to confirm the prior subagent committed its changes and did not leave unintended dirty work. If a loop part intentionally has no file changes, record that explicitly in the orchestrator notes before proceeding.
+6. **Keep commits attributable to SDD boundaries**: Implementation and remediation commits should reference the current parent task and spec number. Review commits, when needed, should clearly identify the reviewed task and whether findings are blocking or advisory.
+7. **Report completion only after all tasks are complete**: When the final parent task has a clean review, verify all tasks are `[x]`, all proof artifacts exist, the final quality gates pass, and the working tree is clean. Then report that all SDD-3 tasks are complete and hand off to validation.
+
+### Subagent Prompt Minimums
+
+Every modified-batch subagent prompt must include:
+
+- selected spec directory and task file path
+- current parent task number and scope
+- instruction to read the SDD-3 phase reference before beginning
+- required role for this loop part: implement, review, or remediate
+- expected commit behavior before returning
+- verification commands or repository quality gates to run
+- expected return summary: files changed, proof artifacts touched, tests/gates run, commit hash, and remaining blockers
 
 ## Implementation Workflow with Self-Verification
 

--- a/tests/test_sdd_subagent_batch_contract.py
+++ b/tests/test_sdd_subagent_batch_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = ROOT / "skill" / "SKILL.md"
+PHASE_3 = ROOT / "skill" / "references" / "sdd-3-manage-tasks.md"
+
+
+def test_router_requires_phase_reference_context_when_delegating():
+    text = SKILL_MD.read_text().lower()
+
+    assert "whenever you delegate sdd work to a subagent" in text
+    assert "read the relevant sdd phase reference file before beginning" in text
+
+
+def test_phase_3_documents_batch_subagent_loop():
+    phase_3 = PHASE_3.read_text().lower()
+
+    assert "batch mode with subagents" in phase_3
+    assert "implement → review → remediate → repeat" in phase_3
+    assert "separate subagents for each loop part" in phase_3
+    assert "read `skill/references/sdd-3-manage-tasks.md`" in phase_3
+    assert "git status --short" in phase_3
+    assert "git log --oneline -1" in phase_3
+    assert "report that all sdd-3 tasks are complete" in phase_3


### PR DESCRIPTION
## Why?

SDD-3 needs a documented advanced execution option for larger implementation phases where independent implementation, review, and remediation passes can improve quality without pausing after each parent task.

## What Changed?

Added an subagent-=based batch mode to SDD-3 that coordinates parent tasks through an implement → review → remediate → repeat loop.

### Key Changes:
- Added a router-level delegation reminder requiring subagents to read the relevant SDD phase reference before work begins.
- Added Batch Mode with Subagents guidance, including sequential orchestration, clean handoffs, commit verification, and completion gates.
- Added static contract tests covering the delegation and SDD-3 batch-mode requirements.

**Files Modified:** `skill/SKILL.md`, `skill/references/sdd-3-manage-tasks.md`, `tests/test_sdd_subagent_batch_contract.py`

## Additional Notes

- **Breaking Changes:** None.
- **Performance Implications:** None.
- **Security Considerations:** No runtime or credential-handling changes.
- **Testing Strategy:** `python -m pytest -q` (17 passed); `pre-commit run --all-files` (passed).
- **Dependencies:** None.
- **Configuration Changes:** None.
- **Known Limitations:** This documents the orchestration contract; it does not add a runtime subagent implementation.
- **Related Issues:** N/A.

## Review Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated for new functionality
- [x] Documentation updated if needed
- [x] No breaking changes (or migration path documented)
- [x] Performance impact considered
- [x] Security implications reviewed
- [x] Dependencies reviewed and approved


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and string-based contract tests only; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Documents an **advanced SDD-3 execution path** for finishing implementation without pausing after every parent task, while still enforcing review and remediation.
> 
> **`SKILL.md`** adds a **Delegation Reminder**: any SDD work handed to a subagent must tell that subagent to read the relevant SDD phase reference first, so proof, task-state, and commit rules stay in force outside the main orchestrator.
> 
> **`sdd-3-manage-tasks.md`** introduces **Batch Mode with Subagents** as checkpoint option 4: the main agent runs parent tasks in order through **implement → review → remediate → repeat**, using separate subagents per step, mandatory SDD-3 context in prompts, `git status` / `git log` checks between steps, task-attributed commits, and a clean handoff to validation only when all tasks and gates are done. It also defines **subagent prompt minimums** (spec paths, role, gates, return summary).
> 
> **`tests/test_sdd_subagent_batch_contract.py`** adds static assertions that those delegation and batch-loop phrases remain in the skill docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af93400dc90b5da043a38e98c243c83725c79755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->