### PR TITLE
feat(skill): require proof artifacts on disk before a spec can be validated

### DIFF
--- a/skill/scripts/assess-sdd-state.py
+++ b/skill/scripts/assess-sdd-state.py
@@ -38,15 +38,26 @@ def _strip_code_fences(text):
 
     Counting those as real unchecked boxes strands a finished spec in Phase 3
     forever, so every content scan runs on the stripped text.
+
+    A fence that is opened and never closed is not treated as a block: its lines
+    are restored, because a truncated task file must not be able to hide
+    unfinished work behind a missing closing fence.
     """
     kept = []
-    in_fence = False
+    pending = None  # lines held inside a fence that has not closed yet
     for line in text.splitlines():
         if _FENCE.match(line):
-            in_fence = not in_fence
+            pending = [] if pending is None else None
             continue
-        if not in_fence:
+        if pending is None:
             kept.append(line)
+        else:
+            pending.append(line)
+    if pending:
+        # The final fence never closed, so it does not delimit a block. Restoring
+        # its lines keeps a truncated task file from hiding real task state:
+        # dropping them would make an unfinished spec look finished.
+        kept.extend(pending)
     return "\n".join(kept)
 
 
@@ -62,11 +73,23 @@ def _is_placeholder(text, match):
 
 
 def _status_value_tokens(text):
-    """Yield PASS/FAIL tokens that appear in a status-value position."""
+    """Yield PASS/FAIL tokens that appear in a status-value position.
+
+    The qualifying prefix must sit on the *same line* as the token. Scanning
+    backwards across newlines would let a bare ``PASS`` inherit the colon, pipe,
+    or bold marker of an earlier line, so prose such as::
+
+        ## Notes:
+
+        PASS
+
+    would be read as a verdict and open the planning gate.
+    """
     for match in _ANY_VERDICT_TOKEN.finditer(text):
         if _is_placeholder(text, match):
             continue
-        before = text[:match.start()].rstrip()
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        before = text[line_start:match.start()].rstrip()
         if before.endswith(_STATUS_VALUE_PREFIXES):
             yield match.group(1).upper()
 

--- a/skill/scripts/assess-sdd-state.py
+++ b/skill/scripts/assess-sdd-state.py
@@ -1,13 +1,78 @@
 #!/usr/bin/env python3
-import os
 import re
 from pathlib import Path
 import json
 
 import sys
 
-def _authoritative_verdict(text):
-    r"""Return the authoritative PASS/FAIL verdict for an audit/validation report.
+# Verdicts. A report that yields UNVERIFIED has no trustworthy verdict and must
+# not be treated as a passing gate.
+PASS = "PASS"
+FAIL = "FAIL"
+UNVERIFIED = "UNVERIFIED"
+
+_FENCE = re.compile(r'^\s*(?:```|~~~)')
+
+_AUTHORITATIVE_STATUS = re.compile(
+    r'^\s*(?:[-*+]\s*)?(?:\*\*)?overall(?:\s+status)?(?:\*\*)?\s*:'
+    r'\s*(?:\*\*)?\s*(PASS|FAIL)\b',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_ANY_VERDICT_TOKEN = re.compile(r'\b(PASS|FAIL)\b', re.IGNORECASE)
+
+# A verdict token is only a status *value* when it sits where a value goes: after
+# a colon, inside a table cell, or wrapped in bold. Bare prose ("no gate returned
+# FAIL", "all required gates pass") is not a verdict.
+_STATUS_VALUE_PREFIXES = (":", "|", "**")
+
+
+def _strip_code_fences(text):
+    """Drop fenced code blocks so template examples cannot be read as state.
+
+    Task files legitimately contain fenced examples such as::
+
+        ```markdown
+        - [ ] N.N description
+        ```
+
+    Counting those as real unchecked boxes strands a finished spec in Phase 3
+    forever, so every content scan runs on the stripped text.
+    """
+    kept = []
+    in_fence = False
+    for line in text.splitlines():
+        if _FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def _is_placeholder(text, match):
+    """True when the captured verdict is the unfilled `PASS/FAIL` template.
+
+    The documented report template ships the literal line
+    ``- Overall Status: PASS/FAIL``. Read naively that parses as PASS, so an
+    audit whose verdict was never filled in reads as a passing gate. Treat the
+    slash form as "no verdict recorded" instead.
+    """
+    return text[match.end():match.end() + 1] == "/" or text[max(0, match.start() - 1):match.start()] == "/"
+
+
+def _status_value_tokens(text):
+    """Yield PASS/FAIL tokens that appear in a status-value position."""
+    for match in _ANY_VERDICT_TOKEN.finditer(text):
+        if _is_placeholder(text, match):
+            continue
+        before = text[:match.start()].rstrip()
+        if before.endswith(_STATUS_VALUE_PREFIXES):
+            yield match.group(1).upper()
+
+
+def _report_verdict(text):
+    r"""Return PASS, FAIL, or UNVERIFIED for an audit/validation report.
 
     The report's Executive Summary carries the verdict on an
     ``Overall Status: PASS/FAIL`` line (audits) or ``Overall: PASS/FAIL`` line
@@ -55,30 +120,90 @@ def _authoritative_verdict(text):
     └──────────────────────────────── Allow spaces after ":"
 
     Strategy:
-      1. Search for the first explicitly formatted status line and return the
-         PASS/FAIL token immediately after its colon. A parenthetical note such
-         as ``PASS (was FAIL on run 1)`` therefore stays PASS.
-      2. Otherwise fall back to a per-gate scan: any FAIL marks the report
-         failed (preserves behaviour for reports without a summary line).
-
-    Returns "PASS", "FAIL", or None when no verdict can be determined.
+      1. Return the first authoritative status line's verdict. A parenthetical
+         note such as ``PASS (was FAIL on run 1)`` therefore stays PASS. An
+         unfilled ``PASS/FAIL`` placeholder is skipped, not read as PASS.
+      2. Otherwise scan for verdict tokens in status-value position (after a
+         colon, in a table cell, or bolded): any FAIL wins, else PASS. Bare
+         prose is ignored, and the ``(PASS/FAIL)`` column legend is ignored.
+      3. Otherwise return UNVERIFIED. Callers must treat that as "gate not
+         satisfied", never as a pass.
     """
-    status_line = re.compile(
-        r'^\s*(?:[-*+]\s*)?(?:\*\*)?overall(?:\s+status)?(?:\*\*)?\s*:'
-        r'\s*(?:\*\*)?\s*(PASS|FAIL)\b',
-        re.IGNORECASE | re.MULTILINE,
+    body = _strip_code_fences(text)
+
+    for match in _AUTHORITATIVE_STATUS.finditer(body):
+        if not _is_placeholder(body, match):
+            return match.group(1).upper()
+
+    tokens = set(_status_value_tokens(body))
+    if FAIL in tokens:
+        return FAIL
+    if PASS in tokens:
+        return PASS
+    return UNVERIFIED
+
+
+def _read_report_verdict(path):
+    """Read one report and return (verdict, error).
+
+    An unreadable or empty report is UNVERIFIED with a reason, never a silent
+    pass. `error` is None on a clean read.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return UNVERIFIED, f"{path.name}: not found"
+    except OSError as exc:
+        return UNVERIFIED, f"{path.name}: unreadable ({exc.strerror})"
+    except UnicodeDecodeError:
+        return UNVERIFIED, f"{path.name}: not valid UTF-8"
+
+    if not text.strip():
+        return UNVERIFIED, f"{path.name}: file is empty"
+
+    verdict = _report_verdict(text)
+    if verdict is UNVERIFIED:
+        return verdict, f"{path.name}: no authoritative 'Overall Status: PASS' line found"
+    return verdict, None
+
+
+def _read_text(path):
+    """Read a task file, returning (text, error)."""
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except FileNotFoundError:
+        return "", f"{path.name}: not found"
+    except OSError as exc:
+        return "", f"{path.name}: unreadable ({exc.strerror})"
+    except UnicodeDecodeError:
+        return "", f"{path.name}: not valid UTF-8"
+
+
+def _is_parents_only(tasks_text):
+    """True when sub-tasks are still placeholders.
+
+    The Phase 2 template writes a bare ``TBD`` line under each parent task's
+    Tasks heading. Requiring the whole line to be TBD keeps a sub-task that
+    merely mentions the word ("replace the TBD placeholder in config") from
+    reverting a fully planned spec back to parent-tasks-only.
+    """
+    return any(
+        line.strip().lstrip("#").strip() == "TBD"
+        for line in _strip_code_fences(tasks_text).splitlines()
     )
 
-    match = status_line.search(text)
-    if match:
-        return match.group(1).upper()
 
-    # No authoritative line: fall back to a whole-document gate scan.
-    if re.search(r'\*\*FAIL\*\*|\bFAIL\b', text):
-        return "FAIL"
-    if re.search(r'\bPASS\b', text):
-        return "PASS"
-    return None
+_CHECKBOX = re.compile(r'^\s*(?:[-*+]\s+|#{1,6}\s+)?\[([ x~])\]', re.IGNORECASE)
+
+
+def _has_incomplete_tasks(tasks_text):
+    """True when any real checkbox is still `[ ]` or `[~]` (fences excluded)."""
+    for line in _strip_code_fences(tasks_text).splitlines():
+        match = _CHECKBOX.match(line)
+        if match and match.group(1).lower() in (" ", "~"):
+            return True
+    return False
+
 
 def get_specs_dir(base_path=None):
     """Locate the specs directory starting from the current location or provided base_path."""
@@ -123,7 +248,8 @@ def assess_spec_dir(spec_path):
         },
         "phase": 0,
         "detailed_state": "",
-        "action_required": ""
+        "action_required": "",
+        "blockers": []
     }
 
     # Logic matching SKILL.md state assessment
@@ -135,88 +261,78 @@ def assess_spec_dir(spec_path):
         else:
             state["detailed_state"] = "S1_START"
             state["action_required"] = "Generate Spec (Phase 1)"
-    elif not state["files_found"]["tasks"]:
+        return state
+
+    if not state["files_found"]["tasks"]:
         state["phase"] = 2
         state["detailed_state"] = "S2_START"
         state["action_required"] = "Generate Task List (Phase 2)"
-    elif not state["files_found"]["audit"]:
+        return state
+
+    tasks_text, tasks_error = _read_text(spec_dir / tasks_file)
+    if tasks_error:
         state["phase"] = 2
+        state["detailed_state"] = "S2_TASKS_UNREADABLE"
+        state["action_required"] = "Repair the task list before continuing (Phase 2)"
+        state["blockers"].append(tasks_error)
+        return state
 
-        # Check if tasks are parents only (TBD marker)
-        tasks_path = spec_dir / tasks_file
-        has_tbd = False
-        try:
-            with open(tasks_path, 'r', encoding='utf-8') as f:
-                if re.search(r'## TBD|\bTBD\b', f.read()):
-                    has_tbd = True
-        except Exception:
-            pass
-
-        if has_tbd:
+    if not state["files_found"]["audit"]:
+        state["phase"] = 2
+        if _is_parents_only(tasks_text):
             state["detailed_state"] = "S2_PARENTS_DONE"
             state["action_required"] = "Review Parent Tasks & Generate Sub-tasks (Phase 2)"
         else:
             state["detailed_state"] = "S2_SUBTASKS_DONE"
             state["action_required"] = "Generate Planning Audit (Phase 2)"
+        return state
+
+    # The planning audit is a gate: it opens only on an explicit PASS verdict.
+    audit_verdict, audit_error = _read_report_verdict(spec_dir / audit_file)
+    if audit_verdict == FAIL:
+        state["phase"] = 2
+        state["detailed_state"] = "S2_AUDIT_FAILED"
+        state["action_required"] = "Fix Planning Audit Failures (Phase 2)"
+        return state
+    if audit_verdict != PASS:
+        state["phase"] = 2
+        state["detailed_state"] = "S2_AUDIT_UNVERIFIED"
+        state["action_required"] = (
+            "Planning audit verdict could not be verified; re-run the audit and record "
+            "'Overall Status: PASS' before implementation (Phase 2)"
+        )
+        state["blockers"].append(audit_error)
+        return state
+
+    state["detailed_state"] = "S2_COMPLETE"
+
+    if _has_incomplete_tasks(tasks_text):
+        state["phase"] = 3
+        state["detailed_state"] = "S3_MIDFLIGHT"
+        state["action_required"] = "Implement Tasks (Phase 3)"
+        return state
+
+    if not state["files_found"]["validation"]:
+        state["phase"] = 4
+        state["detailed_state"] = "S4_START"
+        state["action_required"] = "Validate Implementation (Phase 4)"
+        return state
+
+    state["phase"] = 4
+    validation_verdict, validation_error = _read_report_verdict(spec_dir / validation_file)
+    if validation_verdict == PASS:
+        state["detailed_state"] = "S4_COMPLETE"
+        state["action_required"] = "Validation Complete. Start next feature (Phase 1)"
+    elif validation_verdict == FAIL:
+        state["detailed_state"] = "S4_FAILED"
+        state["action_required"] = "Fix Validation Failures (Phase 4)"
     else:
-        # Check audit gates for FAIL using the authoritative verdict line
-        audit_path = spec_dir / audit_file
-        audit_failed = False
-        try:
-            with open(audit_path, 'r', encoding='utf-8') as f:
-                if _authoritative_verdict(f.read()) == "FAIL":
-                    audit_failed = True
-        except Exception:
-            pass
-
-        if audit_failed:
-            state["phase"] = 2
-            state["detailed_state"] = "S2_AUDIT_FAILED"
-            state["action_required"] = "Fix Planning Audit Failures (Phase 2)"
-            return state # Return early to trap it in Phase 2
-        else:
-            state["detailed_state"] = "S2_COMPLETE"
-
-        # Check task completion
-        tasks_path = spec_dir / tasks_file
-        incomplete_tasks = False
-        try:
-            with open(tasks_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-                # Look for incomplete markdown checkboxes
-                if re.search(r'\[\s\]', content) or re.search(r'\[~\]', content):
-                    incomplete_tasks = True
-        except Exception:
-            pass
-
-        if incomplete_tasks:
-            state["phase"] = 3
-            state["action_required"] = "Implement Tasks (Phase 3)"
-            # At this point, we could probably detect midflight vs start, but both are Phase 3
-            state["detailed_state"] = "S3_MIDFLIGHT"
-        elif not state["files_found"]["validation"]:
-            state["phase"] = 4
-            state["detailed_state"] = "S4_START"
-            state["action_required"] = "Validate Implementation (Phase 4)"
-        else:
-            state["phase"] = 4
-
-            # Check validation for FAIL using the authoritative verdict line
-            val_path = spec_dir / validation_file
-            val_failed = False
-            try:
-                with open(val_path, 'r', encoding='utf-8') as f:
-                    if _authoritative_verdict(f.read()) == "FAIL":
-                        val_failed = True
-            except Exception:
-                pass
-
-            if val_failed:
-                state["detailed_state"] = "S4_FAILED"
-                state["action_required"] = "Fix Validation Failures (Phase 4)"
-            else:
-                state["detailed_state"] = "S4_COMPLETE"
-                state["action_required"] = "Validation Complete. Start next feature (Phase 1)"
+        state["detailed_state"] = "S4_UNVERIFIED"
+        state["action_required"] = (
+            "Validation verdict could not be verified; re-run validation and record "
+            "'Overall: PASS' (Phase 4)"
+        )
+        state["blockers"].append(validation_error)
 
     return state
 
@@ -254,17 +370,19 @@ def main(base_path=None):
 
     active = sorted(
         [s for s in result["active_specs"] if s.get("phase", 0) in [1, 2, 3, 4]],
-        key=lambda x: (x["phase"], -int(x["sequence"])), # Prioritize highest phase, then highest sequence
+        key=lambda x: (x["phase"], int(x["sequence"])), # Prioritize highest phase, then highest sequence
         reverse=True
     )
 
     if active:
         # Prioritize any incomplete phases over a completed phase 4
-        incomplete = [s for s in active if s.get("phase", 0) < 4 or s.get("detailed_state") == "S4_FAILED" or s.get("detailed_state") == "S4_START"]
+        incomplete = [s for s in active if s.get("phase", 0) < 4 or s.get("detailed_state") != "S4_COMPLETE"]
 
         if incomplete:
             target = incomplete[0]
             result["recommendation"] = f"Phase {target['phase']}: {target['action_required']} for feature '{target['feature']}' (Sequence {target['sequence']})"
+            if target.get("blockers"):
+                result["recommendation"] += f" | blockers: {'; '.join(target['blockers'])}"
         else:
             # Everything is S4_COMPLETE
             target = active[0]

--- a/skill/scripts/assess-sdd-state.py
+++ b/skill/scripts/assess-sdd-state.py
@@ -217,6 +217,10 @@ def _is_parents_only(tasks_text):
 
 
 _CHECKBOX = re.compile(r'^\s*(?:[-*+]\s+|#{1,6}\s+)?\[([ x~])\]', re.IGNORECASE)
+_PARENT_TASK = re.compile(
+    r'^\s*(?:[-*+]\s+|#{1,6}\s+)?\[([ x~])\]\s*(\d+)\.0\b',
+    re.IGNORECASE,
+)
 
 
 def _has_incomplete_tasks(tasks_text):
@@ -226,6 +230,52 @@ def _has_incomplete_tasks(tasks_text):
         if match and match.group(1).lower() in (" ", "~"):
             return True
     return False
+
+
+def _completed_parent_tasks(tasks_text):
+    """Return the numbers of parent tasks marked complete, e.g. [1, 2].
+
+    Recognises the documented ``### [x] N.0 Title`` form. Task files that do not
+    use it yield no parent tasks, in which case the proof gate falls back to
+    requiring at least one proof artifact rather than a per-task mapping.
+    """
+    completed = []
+    for line in _strip_code_fences(tasks_text).splitlines():
+        match = _PARENT_TASK.match(line)
+        if match and match.group(1).lower() == "x":
+            completed.append(int(match.group(2)))
+    return completed
+
+
+def _missing_proof_artifacts(spec_dir, seq_num, tasks_text):
+    """Return the proof artifacts an implemented spec still owes.
+
+    Phase 3 requires one proof file per completed parent task at
+    ``[NN]-proofs/[NN]-task-[TT]-proofs.md``, created *before* the task's
+    commit. Without this check the router advances to validation with zero
+    evidence on disk, which is the one thing the workflow promises never to do.
+
+    Evidence is required unconditionally. When the task file uses the documented
+    ``### [x] N.0`` headings, each completed parent task must have its own proof
+    file. When it does not, the per-task mapping cannot be derived, so the gate
+    falls back to the weakest requirement that is still a requirement: the spec
+    must have produced at least one proof artifact.
+    """
+    proofs_dir = spec_dir / f"{seq_num}-proofs"
+    completed_parents = _completed_parent_tasks(tasks_text)
+
+    if completed_parents:
+        return [
+            expected
+            for expected in (
+                f"{seq_num}-task-{parent:02d}-proofs.md" for parent in completed_parents
+            )
+            if not (proofs_dir / expected).is_file()
+        ]
+
+    if not any(proofs_dir.glob(f"{seq_num}-task-*-proofs.md")):
+        return [f"{proofs_dir.name}/{seq_num}-task-NN-proofs.md (at least one)"]
+    return []
 
 
 def get_specs_dir(base_path=None):
@@ -335,17 +385,30 @@ def assess_spec_dir(spec_path):
         state["action_required"] = "Implement Tasks (Phase 3)"
         return state
 
-    if not state["files_found"]["validation"]:
-        state["phase"] = 4
-        state["detailed_state"] = "S4_START"
-        state["action_required"] = "Validate Implementation (Phase 4)"
+    # A spec that already carries a passing validation report has cleared a
+    # later and stronger gate, so it is reported as complete rather than
+    # reopened. Every other route into validation requires evidence on disk.
+    validation_verdict, validation_error = (None, None)
+    if state["files_found"]["validation"]:
+        validation_verdict, validation_error = _read_report_verdict(spec_dir / validation_file)
+        if validation_verdict == PASS:
+            state["phase"] = 4
+            state["detailed_state"] = "S4_COMPLETE"
+            state["action_required"] = "Validation Complete. Start next feature (Phase 1)"
+            return state
+
+    missing_proofs = _missing_proof_artifacts(spec_dir, seq_num, tasks_text)
+    if missing_proofs:
+        state["phase"] = 3
+        state["detailed_state"] = "S3_PROOFS_MISSING"
+        state["action_required"] = "Create the missing proof artifacts before validation (Phase 3)"
+        state["blockers"].extend(f"missing proof artifact: {name}" for name in missing_proofs)
         return state
 
     state["phase"] = 4
-    validation_verdict, validation_error = _read_report_verdict(spec_dir / validation_file)
-    if validation_verdict == PASS:
-        state["detailed_state"] = "S4_COMPLETE"
-        state["action_required"] = "Validation Complete. Start next feature (Phase 1)"
+    if not state["files_found"]["validation"]:
+        state["detailed_state"] = "S4_START"
+        state["action_required"] = "Validate Implementation (Phase 4)"
     elif validation_verdict == FAIL:
         state["detailed_state"] = "S4_FAILED"
         state["action_required"] = "Fix Validation Failures (Phase 4)"

--- a/tests/test_assess_sdd_state.py
+++ b/tests/test_assess_sdd_state.py
@@ -19,6 +19,18 @@ def workspace():
         workspace_path = Path(temp_dir)
         yield workspace_path
 
+# A minimal audit report that actually records a passing verdict. An empty or
+# verdict-less audit file is not a passing gate, so fixtures that need the
+# workflow to advance past Phase 2 must supply a real verdict.
+PASSING_AUDIT = """# 01-audit-auth.md
+
+## Executive Summary
+
+- Overall Status: PASS
+- Required Gate Failures: 0
+"""
+
+
 def test_no_specs_dir(workspace):
     """Test S1_START: Empty Workspace"""
     result = assess.main(base_path=workspace)
@@ -59,7 +71,7 @@ def test_phase_3_start(workspace):
     feature_dir.mkdir(parents=True)
 
     (feature_dir / "01-spec-auth.md").touch()
-    (feature_dir / "01-audit-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").write_text(PASSING_AUDIT)
 
     with open(feature_dir / "01-tasks-auth.md", "w") as f:
         f.write("# Tasks\n- [ ] Task 1\n- [x] Task 2")
@@ -80,10 +92,11 @@ def test_phase_4_start_selects_completed_unvalidated_spec(workspace):
     feature_dir.mkdir(parents=True)
 
     (feature_dir / "01-spec-auth.md").touch()
-    (feature_dir / "01-audit-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").write_text(PASSING_AUDIT)
 
     with open(feature_dir / "01-tasks-auth.md", "w") as f:
         f.write("# Tasks\n- [x] Task 1\n- [x] Task 2")
+
 
     result = assess.main(base_path=workspace)
     spec = result["active_specs"][0]
@@ -152,10 +165,11 @@ def test_S4_FAILED(workspace):
     feature_dir.mkdir(parents=True)
 
     (feature_dir / "01-spec-auth.md").touch()
-    (feature_dir / "01-audit-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").write_text(PASSING_AUDIT)
 
     with open(feature_dir / "01-tasks-auth.md", "w") as f:
         f.write("# Tasks\n- [x] Task 1")
+
 
     validation_dir = docs_specs / "01-validation-auth"
     validation_dir.mkdir(parents=True, exist_ok=True)
@@ -176,7 +190,7 @@ def test_S4_COMPLETE(workspace):
     feature_dir.mkdir(parents=True)
 
     (feature_dir / "01-spec-auth.md").touch()
-    (feature_dir / "01-audit-auth.md").touch()
+    (feature_dir / "01-audit-auth.md").write_text(PASSING_AUDIT)
 
     with open(feature_dir / "01-tasks-auth.md", "w") as f:
         f.write("# Tasks\n- [x] Task 1")
@@ -343,3 +357,197 @@ def test_validation_pass_with_fail_word_in_body_is_complete(workspace):
 
     assert spec["phase"] == 4
     assert spec["detailed_state"] == "S4_COMPLETE"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed gate regression tests
+#
+# The planning audit is the workflow's only barrier between planning and
+# implementation. Absence of a verdict is not a passing verdict: every report
+# the assessor cannot read as an explicit PASS must hold the spec in Phase 2.
+# ---------------------------------------------------------------------------
+
+def _spec_through_audit(workspace, audit_body, tasks_body, sequence="01", feature="auth"):
+    """Create one spec directory with spec, tasks, and audit files."""
+    feature_dir = workspace / "docs" / "specs" / f"{sequence}-spec-{feature}"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / f"{sequence}-spec-{feature}.md").write_text("# Spec\n")
+    (feature_dir / f"{sequence}-tasks-{feature}.md").write_text(tasks_body)
+    (feature_dir / f"{sequence}-audit-{feature}.md").write_text(audit_body)
+    return feature_dir
+
+
+def test_empty_audit_file_does_not_open_the_gate(workspace):
+    """An audit file truncated by an interrupted session is not a passing gate."""
+    _spec_through_audit(workspace, "", "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_UNVERIFIED"
+    assert any("empty" in blocker for blocker in spec["blockers"])
+
+
+def test_unfilled_pass_slash_fail_placeholder_does_not_open_the_gate(workspace):
+    """The literal template line `Overall Status: PASS/FAIL` records no verdict."""
+    body = (
+        "## Executive Summary\n\n"
+        "- Overall Status: PASS/FAIL\n"
+        "- Required Gate Failures: 3\n"
+    )
+    _spec_through_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_UNVERIFIED"
+
+
+def test_unfilled_placeholder_with_failing_gateboard_reads_as_failed(workspace):
+    """A placeholder verdict falls through to the gateboard, which says FAIL."""
+    body = (
+        "## Executive Summary\n\n"
+        "- Overall Status: PASS/FAIL\n\n"
+        "## Gateboard\n\n"
+        "| Gate | Status |\n| --- | --- |\n"
+        "| Requirement-to-test traceability | FAIL |\n"
+    )
+    _spec_through_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_FAILED"
+
+
+def test_audit_whose_failure_is_only_in_prose_does_not_open_the_gate(workspace):
+    """Lowercase prose is not a verdict, so the gate stays closed rather than open."""
+    body = "# Audit\n\nResult: two required gates failed and must be remediated.\n"
+    _spec_through_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_UNVERIFIED"
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root can read files regardless of mode bits",
+)
+def test_unreadable_audit_does_not_open_the_gate(workspace):
+    """A read error must surface as a blocker, not be swallowed into a pass."""
+    feature_dir = _spec_through_audit(
+        workspace, "- Overall Status: FAIL\n", "# Tasks\n- [ ] Task 1"
+    )
+    audit_path = feature_dir / "01-audit-auth.md"
+    audit_path.chmod(0o000)
+    try:
+        spec = assess.main(base_path=workspace)["active_specs"][0]
+    finally:
+        audit_path.chmod(0o644)
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_UNVERIFIED"
+    assert any("unreadable" in blocker for blocker in spec["blockers"])
+
+
+def test_pass_fail_column_legend_does_not_trap_a_passing_audit(workspace):
+    """A `Status (PASS/FAIL)` column header is a legend, not a failing gate."""
+    body = (
+        "# Audit\n\n"
+        "| Gate | Status (PASS/FAIL) |\n| --- | --- |\n"
+        "| Requirement-to-test traceability | PASS |\n"
+        "| Proof artifact verifiability | PASS |\n"
+    )
+    _spec_through_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["detailed_state"] == "S3_MIDFLIGHT"
+    assert spec["phase"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Content-scan precision: markdown prose and fenced examples are not state
+# ---------------------------------------------------------------------------
+
+def test_tbd_inside_a_subtask_does_not_revert_to_parents_only(workspace):
+    """The word TBD in a sub-task must not erase generated sub-tasks."""
+    docs_specs = workspace / "docs" / "specs" / "01-spec-auth"
+    docs_specs.mkdir(parents=True)
+    (docs_specs / "01-spec-auth.md").write_text("# Spec\n")
+    (docs_specs / "01-tasks-auth.md").write_text(
+        "### [x] 1.0 Parent\n\n#### 1.0 Tasks\n\n- [x] 1.1 Replace the TBD placeholder in config\n"
+    )
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["detailed_state"] == "S2_SUBTASKS_DONE"
+    assert spec["action_required"] == "Generate Planning Audit (Phase 2)"
+
+
+def test_bare_tbd_line_still_detects_parents_only(workspace):
+    """Regression guard: the template's bare TBD line still means parents-only."""
+    docs_specs = workspace / "docs" / "specs" / "01-spec-auth"
+    docs_specs.mkdir(parents=True)
+    (docs_specs / "01-spec-auth.md").write_text("# Spec\n")
+    (docs_specs / "01-tasks-auth.md").write_text(
+        "### [ ] 1.0 Parent\n\n#### 1.0 Tasks\n\nTBD\n"
+    )
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["detailed_state"] == "S2_PARENTS_DONE"
+
+
+def test_checkbox_inside_a_code_fence_is_not_an_incomplete_task(workspace):
+    """A fenced template example must not strand a finished spec in Phase 3."""
+    tasks = (
+        "### [x] 1.0 Parent\n\n#### 1.0 Tasks\n\n- [x] 1.1 done\n\n"
+        "Sub-task format:\n\n```markdown\n- [ ] N.N description\n```\n"
+    )
+    feature_dir = _spec_through_audit(workspace, PASSING_AUDIT, tasks)
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_START"
+
+
+def test_heading_style_incomplete_parent_task_is_detected(workspace):
+    """Regression guard: `### [ ] 1.0` is a real unchecked task, fences aside."""
+    _spec_through_audit(workspace, PASSING_AUDIT, "### [ ] 1.0 Parent\n\n- [ ] 1.1 todo\n")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 3
+    assert spec["detailed_state"] == "S3_MIDFLIGHT"
+
+
+# ---------------------------------------------------------------------------
+# Selection order
+# ---------------------------------------------------------------------------
+
+def test_highest_sequence_wins_within_the_same_phase(workspace):
+    """Two specs in the same phase: the newest sequence is the active one."""
+    for sequence, feature in (("01", "older"), ("02", "newer")):
+        _spec_through_audit(
+            workspace, PASSING_AUDIT, "# Tasks\n- [ ] Task 1", sequence, feature
+        )
+
+    result = assess.main(base_path=workspace)
+
+    assert "Sequence 02" in result["recommendation"]
+    assert "newer" in result["recommendation"]
+
+
+def test_validation_without_a_verdict_is_not_complete(workspace):
+    """A validation report with no readable verdict does not close the workflow."""
+    feature_dir = _spec_through_audit(workspace, PASSING_AUDIT, "# Tasks\n- [x] Task 1")
+    (feature_dir / "01-validation-auth.md").write_text("# Validation\n\nLooks good to me.\n")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_UNVERIFIED"

--- a/tests/test_assess_sdd_state.py
+++ b/tests/test_assess_sdd_state.py
@@ -31,6 +31,15 @@ PASSING_AUDIT = """# 01-audit-auth.md
 """
 
 
+def write_proof(feature_dir, sequence="01", task=1):
+    """Create the proof artifact a completed parent task is required to produce."""
+    proofs_dir = feature_dir / f"{sequence}-proofs"
+    proofs_dir.mkdir(exist_ok=True)
+    path = proofs_dir / f"{sequence}-task-{task:02d}-proofs.md"
+    path.write_text(f"# Task {task:02d} Proofs\n")
+    return path
+
+
 def test_no_specs_dir(workspace):
     """Test S1_START: Empty Workspace"""
     result = assess.main(base_path=workspace)
@@ -97,6 +106,7 @@ def test_phase_4_start_selects_completed_unvalidated_spec(workspace):
     with open(feature_dir / "01-tasks-auth.md", "w") as f:
         f.write("# Tasks\n- [x] Task 1\n- [x] Task 2")
 
+    write_proof(feature_dir)
 
     result = assess.main(base_path=workspace)
     spec = result["active_specs"][0]
@@ -170,6 +180,7 @@ def test_S4_FAILED(workspace):
     with open(feature_dir / "01-tasks-auth.md", "w") as f:
         f.write("# Tasks\n- [x] Task 1")
 
+    write_proof(feature_dir)
 
     validation_dir = docs_specs / "01-validation-auth"
     validation_dir.mkdir(parents=True, exist_ok=True)
@@ -367,6 +378,21 @@ def test_validation_pass_with_fail_word_in_body_is_complete(workspace):
 # the assessor cannot read as an explicit PASS must hold the spec in Phase 2.
 # ---------------------------------------------------------------------------
 
+DOCUMENTED_TASKS_ONE_PARENT_DONE = """## Tasks
+
+### [x] 1.0 Add the CLI flag
+
+#### 1.0 Proof Artifact(s)
+
+- CLI: `tool --new-flag` returns expected output demonstrates feature works
+
+#### 1.0 Tasks
+
+- [x] 1.1 Implement the flag
+- [x] 1.2 Add the test
+"""
+
+
 def _spec_through_audit(workspace, audit_body, tasks_body, sequence="01", feature="auth"):
     """Create one spec directory with spec, tasks, and audit files."""
     feature_dir = workspace / "docs" / "specs" / f"{sequence}-spec-{feature}"
@@ -530,6 +556,7 @@ def test_checkbox_inside_a_code_fence_is_not_an_incomplete_task(workspace):
         "Sub-task format:\n\n```markdown\n- [ ] N.N description\n```\n"
     )
     feature_dir = _spec_through_audit(workspace, PASSING_AUDIT, tasks)
+    write_proof(feature_dir)
 
     spec = assess.main(base_path=workspace)["active_specs"][0]
 
@@ -566,6 +593,76 @@ def test_unclosed_fence_does_not_hide_incomplete_tasks(workspace):
 
 
 # ---------------------------------------------------------------------------
+# Proof artifacts are the evidence the workflow promises; the router must look
+# for them on disk instead of trusting a checked box.
+# ---------------------------------------------------------------------------
+
+def test_completed_parent_task_without_proof_artifact_blocks_validation(workspace):
+    """Tasks marked done with no proof file on disk are not ready to validate."""
+    _spec_through_audit(workspace, PASSING_AUDIT, DOCUMENTED_TASKS_ONE_PARENT_DONE)
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 3
+    assert spec["detailed_state"] == "S3_PROOFS_MISSING"
+    assert spec["blockers"] == ["missing proof artifact: 01-task-01-proofs.md"]
+
+
+def test_completed_parent_task_with_proof_artifact_reaches_validation(workspace):
+    """With the proof file present the spec advances to validation."""
+    feature_dir = _spec_through_audit(
+        workspace, PASSING_AUDIT, DOCUMENTED_TASKS_ONE_PARENT_DONE
+    )
+    write_proof(feature_dir)
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_START"
+    assert spec["blockers"] == []
+
+
+def test_undocumented_task_format_still_requires_at_least_one_proof_artifact(workspace):
+    """Evidence is unconditional: an unmappable task file still owes one proof."""
+    _spec_through_audit(workspace, PASSING_AUDIT, "# Tasks\n- [x] Task 1\n")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 3
+    assert spec["detailed_state"] == "S3_PROOFS_MISSING"
+    assert spec["blockers"] == [
+        "missing proof artifact: 01-proofs/01-task-NN-proofs.md (at least one)"
+    ]
+
+
+def test_undocumented_task_format_advances_once_a_proof_exists(workspace):
+    """One proof artifact satisfies the fallback requirement."""
+    feature_dir = _spec_through_audit(workspace, PASSING_AUDIT, "# Tasks\n- [x] Task 1\n")
+    write_proof(feature_dir)
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_START"
+
+
+def test_passing_validation_is_not_reopened_by_the_proof_gate(workspace):
+    """A spec that already cleared validation is reported complete, not reopened.
+
+    The proof gate guards the route *into* validation. Retroactively dragging a
+    spec that already carries a passing validation report back to Phase 3 would
+    reopen shipped work, so the stronger later gate wins.
+    """
+    feature_dir = _spec_through_audit(workspace, PASSING_AUDIT, "# Tasks\n- [x] Task 1\n")
+    (feature_dir / "01-validation-auth.md").write_text("- **Overall:** PASS\n")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 4
+    assert spec["detailed_state"] == "S4_COMPLETE"
+
+
+# ---------------------------------------------------------------------------
 # Selection order
 # ---------------------------------------------------------------------------
 
@@ -585,6 +682,7 @@ def test_highest_sequence_wins_within_the_same_phase(workspace):
 def test_validation_without_a_verdict_is_not_complete(workspace):
     """A validation report with no readable verdict does not close the workflow."""
     feature_dir = _spec_through_audit(workspace, PASSING_AUDIT, "# Tasks\n- [x] Task 1")
+    write_proof(feature_dir)
     (feature_dir / "01-validation-auth.md").write_text("# Validation\n\nLooks good to me.\n")
 
     spec = assess.main(base_path=workspace)["active_specs"][0]

--- a/tests/test_assess_sdd_state.py
+++ b/tests/test_assess_sdd_state.py
@@ -468,6 +468,28 @@ def test_pass_fail_column_legend_does_not_trap_a_passing_audit(workspace):
     assert spec["phase"] == 3
 
 
+def test_bare_verdict_after_a_colon_line_is_not_a_status_value(workspace):
+    """A qualifying prefix must share the token's line, not precede it."""
+    body = "# Audit\n\n## Notes:\n\nPASS\n"
+    _spec_through_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_UNVERIFIED"
+
+
+def test_bare_verdict_after_a_table_row_is_not_a_status_value(workspace):
+    """A token on its own line cannot inherit the pipe of the row above it."""
+    body = "# Audit\n\n| Gate | Status |\n| --- | --- |\n\nPASS\n"
+    _spec_through_audit(workspace, body, "# Tasks\n- [ ] Task 1")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 2
+    assert spec["detailed_state"] == "S2_AUDIT_UNVERIFIED"
+
+
 # ---------------------------------------------------------------------------
 # Content-scan precision: markdown prose and fenced examples are not state
 # ---------------------------------------------------------------------------
@@ -518,6 +540,24 @@ def test_checkbox_inside_a_code_fence_is_not_an_incomplete_task(workspace):
 def test_heading_style_incomplete_parent_task_is_detected(workspace):
     """Regression guard: `### [ ] 1.0` is a real unchecked task, fences aside."""
     _spec_through_audit(workspace, PASSING_AUDIT, "### [ ] 1.0 Parent\n\n- [ ] 1.1 todo\n")
+
+    spec = assess.main(base_path=workspace)["active_specs"][0]
+
+    assert spec["phase"] == 3
+    assert spec["detailed_state"] == "S3_MIDFLIGHT"
+
+
+def test_unclosed_fence_does_not_hide_incomplete_tasks(workspace):
+    """A truncated task file must not look finished.
+
+    Dropping every line after an unterminated fence would hide real unchecked
+    boxes, so an unterminated fence is not treated as a block at all.
+    """
+    tasks = (
+        "### [x] 1.0 Parent\n\n- [x] 1.1 done\n\n"
+        "```markdown\n- [ ] 2.1 still open\n### [ ] 2.0 Parent two\n"
+    )
+    _spec_through_audit(workspace, PASSING_AUDIT, tasks)
 
     spec = assess.main(base_path=workspace)["active_specs"][0]
 


### PR DESCRIPTION
## Why?

Closes the missing-evidence half of #62. Stacked on #63 — review that one first.

The router never looked at the proofs directory. `assess_spec_dir()` collects files with `spec_dir.glob("*.md")`, which does not recurse, so no proof artifact was ever counted. A spec whose tasks were all `[x]` routed straight to validation with **zero evidence on disk**.

That is the one thing the workflow promises never to do. `sdd-3-manage-tasks.md` states the proof file "must be created **BEFORE** the parent task commit" and makes it a blocking verification; the README calls proof artifacts the reason the workflow is "evidence-driven"; Phase 4 exists to validate against them. Nothing verified they existed.

```bash
mkdir -p docs/specs/01-spec-auth
printf '# Spec\n'                             > docs/specs/01-spec-auth/01-spec-auth.md
printf -- '- Overall Status: PASS\n'          > docs/specs/01-spec-auth/01-audit-auth.md
printf '### [x] 1.0 Add the flag\n\n- [x] 1.1 done\n' \
                                              > docs/specs/01-spec-auth/01-tasks-auth.md
python3 skill/scripts/assess-sdd-state.py . | grep recommendation
# before: "Phase 4: Validate Implementation (Phase 4) …"   ← nothing to validate against
# after:  "Phase 3: Create the missing proof artifacts … | blockers: missing proof
#          artifact: 01-task-01-proofs.md"
```

## What Changed?

Evidence is required unconditionally to enter validation:

- When the task file uses the documented `### [x] N.0` headings, each completed parent task must have its own `NN-proofs/NN-task-TT-proofs.md`.
- When it does not, the per-task mapping cannot be derived, so the gate falls back to the weakest requirement that is still a requirement: the spec must have produced **at least one** proof artifact.

Specs missing evidence are held in Phase 3 as `S3_PROOFS_MISSING`, with the expected filenames listed in `blockers` so the message is actionable rather than just a refusal.

The gate guards the route *into* validation and does not reopen finished work: a spec already carrying a passing validation report has cleared a later and stronger gate and is still reported `S4_COMPLETE`. There is a test pinning that, because retroactively dragging shipped features back to Phase 3 would be a bug, not strictness.

## Additional Notes

**This is a deliberate behavioural break, and it is the point of the PR.** An in-flight spec whose tasks are complete but which never produced proof artifacts will now be held in Phase 3 instead of advancing to validation. Creating the proof file that the workflow already required is what unblocks it.

If you would rather not ship that in a patch release, the two obvious variants are: gate only the documented `### [x] N.0` form and leave unmappable task files alone, or report the gap as a warning field instead of holding the phase. I went with the strict reading because a gate that exempts the files it cannot parse is not a gate. Say which you prefer and I will adjust.

**What this is not:** the router is a router, not an authorization boundary. A hand-written validation report bypasses this check, as it bypasses every other state check. The value here is that the *agent* can no longer walk into Phase 4 with nothing to validate.

5 new tests, 3 RED on `main`. Two are guards that must pass both before and after: one proof artifact satisfies the fallback requirement, and a passing validation report is not reopened. Suite 34 → 39. Stdlib only, no new dependencies.

- [x] Linked relevant spec/task IDs — see #62
- [x] Ran tests: `pytest` — 39 passed
- [x] Ran linters/hooks: `pre-commit run --all-files` — all hooks pass, no files modified
- [x] Updated docs, prompts, or skill metadata if behavior changed — no doc change needed; this enforces what `sdd-3-manage-tasks.md` already mandates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a deliberate routing break: in-flight specs with checked tasks but no proof files (or no explicit PASS verdict) will be held back instead of advancing. It only affects the assessor, not auth or data handling.
> 
> **Overview**
> The SDD state assessor now **fail-closes** planning and validation gates and **blocks Phase 4 until proof files exist on disk**.
> 
> Audit/validation reports must yield an explicit `PASS`. Empty, unreadable, placeholder (`PASS/FAIL`), or prose-only reports become `UNVERIFIED` (or `FAIL` from real status-value tokens) and stay in Phase 2/4 instead of silently advancing. Code fences are stripped so template checkboxes cannot fake incomplete work; unclosed fences are not stripped so truncated tasks cannot hide unfinished boxes.
> 
> Completed tasks no longer route to validation on checkboxes alone. Documented `### [x] N.0` parents each need `NN-proofs/NN-task-TT-proofs.md`; unmappable task files still need at least one proof. Missing evidence is `S3_PROOFS_MISSING` with named `blockers`. A spec that already has a passing validation report stays `S4_COMPLETE` and is not reopened.
> 
> Recommendations now append blockers. Same-phase selection prefers the **highest** sequence. Tests cover the new gates and the fail-closed verdict cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b1432e93c44cc8b7906d502f1d8a65be44c9c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->