### PR TITLE
docs: make the report verdict line unambiguous and fix the gate section name

### DIFF
--- a/prompts/SDD-2-generate-task-list-from-spec.md
+++ b/prompts/SDD-2-generate-task-list-from-spec.md
@@ -358,11 +358,11 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 
 ## Executive Summary
 
-- Overall Status: PASS/FAIL
+- Overall Status: [PASS or FAIL]
 - Required Gate Failures: [count]
 - Flagged Risks: [count]
 
-## Gateboard
+## Gate Overview
 
 | Gate | Status | Why it failed (<=10 words) | Exact fix target |
 | --- | --- | --- | --- |
@@ -400,6 +400,11 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 - Still-failing REQUIRED gates:
 - Newly introduced findings (if any):
 ```
+
+The `Overall Status:` line is the report's authoritative verdict. Record exactly
+one of `PASS` or `FAIL` on it. Reviewers and tooling read that line to decide
+whether planning is complete, so leaving the placeholder in place, or stating the
+outcome only in prose elsewhere in the report, leaves the audit with no verdict.
 
 If all REQUIRED gates pass on the first audit run, keep the report minimal:
 

--- a/prompts/SDD-4-validate-spec-implementation.md
+++ b/prompts/SDD-4-validate-spec-implementation.md
@@ -215,9 +215,13 @@ For each Functional Requirement, Demoable Unit, and Repository Standard:
 
 ### 1) Executive Summary
 
-- **Overall:** PASS/FAIL (list gates tripped)
+- **Overall:** [PASS or FAIL] (list gates tripped)
 - **Implementation Ready:** **Yes/No** with one-sentence rationale
 - **Key metrics:** % Requirements Verified, % Proof Artifacts Working, Files Changed vs Expected
+
+The `**Overall:**` line is the report's authoritative verdict. Record exactly one
+of `PASS` or `FAIL` on it, for the same reason the planning audit does: it is the
+line reviewers and tooling read to decide whether the implementation is validated.
 
 ### 2) Coverage Matrix (required)
 

--- a/skill/references/sdd-2-generate-task-list-from-spec.md
+++ b/skill/references/sdd-2-generate-task-list-from-spec.md
@@ -348,11 +348,11 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 
 ## Executive Summary
 
-- Overall Status: PASS/FAIL
+- Overall Status: [PASS or FAIL]
 - Required Gate Failures: [count]
 - Flagged Risks: [count]
 
-## Gateboard
+## Gate Overview
 
 | Gate | Status | Why it failed (<=10 words) | Exact fix target |
 | --- | --- | --- | --- |
@@ -390,6 +390,11 @@ Use this structure in `[NN]-audit-[feature-name].md`:
 - Still-failing REQUIRED gates:
 - Newly introduced findings (if any):
 ```
+
+The `Overall Status:` line is the report's authoritative verdict. Record exactly
+one of `PASS` or `FAIL` on it. Reviewers and tooling read that line to decide
+whether planning is complete, so leaving the placeholder in place, or stating the
+outcome only in prose elsewhere in the report, leaves the audit with no verdict.
 
 If all REQUIRED gates pass on the first audit run, keep the report minimal:
 

--- a/skill/references/sdd-4-validate-spec-implementation.md
+++ b/skill/references/sdd-4-validate-spec-implementation.md
@@ -203,9 +203,13 @@ For each Functional Requirement, Demoable Unit, and Repository Standard:
 
 ### 1) Executive Summary
 
-- **Overall:** PASS/FAIL (list gates tripped)
+- **Overall:** [PASS or FAIL] (list gates tripped)
 - **Implementation Ready:** **Yes/No** with one-sentence rationale
 - **Key metrics:** % Requirements Verified, % Proof Artifacts Working, Files Changed vs Expected
+
+The `**Overall:**` line is the report's authoritative verdict. Record exactly one
+of `PASS` or `FAIL` on it, for the same reason the planning audit does: it is the
+line reviewers and tooling read to decide whether the implementation is validated.
 
 ### 2) Coverage Matrix (required)
 


### PR DESCRIPTION
## Why?

Two small documentation defects in the audit and validation report templates, both surfaced while investigating #62.

**The verdict is the one placeholder that reads as a filled-in value.** The templates ship it as `- Overall Status: PASS/FAIL` and `- **Overall:** PASS/FAIL`, while every other blank in the same blocks uses the bracket convention — `[count]`, `[Issue]`, `[Question 1]`. An agent that leaves the line untouched has not obviously left it untouched, to a human or to a parser. (#63 makes the assessor treat the slash form as "no verdict recorded" rather than as PASS; this PR removes the ambiguity at the source. The two are complementary but independent — neither needs the other to land.)

**The gate table has two names.** The audit template heads it `## Gateboard`, while the instruction forty lines below tells the agent to "Include only `Executive Summary` and `Gate Overview`". The repository's own audit artifact settles which name won in practice:

```
$ grep -n '^## ' docs/specs/01-spec-ai-techniques-deep-dive-page/01-audit-ai-techniques-deep-dive-page.md
3:## Executive Summary
9:## Gate Overview
20:## Standards Evidence Table (Required)
```

The agent followed the instruction and ignored the template heading. So the heading is the outlier, and renaming it is the change that matches both the instruction and the only real audit in the repo.

## What Changed?

- The verdict placeholders read `[PASS or FAIL]`, consistent with the surrounding lines.
- `## Gateboard` → `## Gate Overview`.
- Each template gains a two-to-three line note stating that the verdict line is authoritative and must record exactly one of `PASS` or `FAIL` — because an outcome stated only in prose elsewhere in the report leaves the report with no verdict at all.
- Applied to both `skill/references/` and `prompts/`, so the two install paths stay in sync.

Documentation only. No script changes, so this does not touch #63 or #64 and can merge in any order relative to them.

## Additional Notes

I deliberately stopped the diff at the two lines that are actually read as state. `- **Implementation Ready:** **Yes/No**` sits three lines below one of them and uses the same slash form, but nothing parses it, so widening the change felt like scope creep. Happy to fold it in if you would rather have the whole block consistent.

- [x] Linked relevant spec/task IDs — see #62
- [x] Ran tests: `pytest` — 22 passed
- [x] Ran linters/hooks: `pre-commit run --all-files` — all hooks pass, no files modified
- [x] Updated docs, prompts, or skill metadata if behavior changed — this PR *is* the doc change; both install paths updated together

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only template wording; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Makes planning-audit and implementation-validation report templates unambiguous so agents fill a real **PASS** or **FAIL** on the executive-summary verdict line instead of leaving `PASS/FAIL` looking like a completed value.
> 
> Renames the audit template heading from `## Gateboard` to `## Gate Overview` so it matches the later “keep the report minimal” instruction. Adds a short note that that verdict line is authoritative for reviewers and tooling.
> 
> Mirrored in both `prompts/` and `skill/references/` for SDD-2 and SDD-4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51937c0d5f911eb5924a4b479466867160ec0d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->